### PR TITLE
Add missing DbSets to AppDbContext

### DIFF
--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
@@ -14,6 +14,8 @@ public class AppDbContext : DbContext
     public DbSet<Perfil> Perfis => Set<Perfil>();
     public DbSet<Usuario> Usuarios => Set<Usuario>();
     public DbSet<Log> Logs => Set<Log>();
+    public DbSet<Funcionalidade> Funcionalidades => Set<Funcionalidade>();
+    public DbSet<PerfilFuncionalidade> PerfilFuncionalidades => Set<PerfilFuncionalidade>();
 
     public override int SaveChanges()
     {


### PR DESCRIPTION
## Summary
- add `DbSet<Funcionalidade>` and `DbSet<PerfilFuncionalidade>` to `AppDbContext`

## Testing
- `dotnet build Sistema.sln -v minimal` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d426d10832c8b99c5da4fdecce8