### PR TITLE
Add Ativo flag and password hash support

### DIFF
--- a/1 - Aplicacao/Sistema.APP/DTOs/PerfilDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/PerfilDto.cs
@@ -4,4 +4,5 @@ public class PerfilDto
 {
     public int Id { get; set; }
     public string Nome { get; set; } = string.Empty;
+    public bool Ativo { get; set; } = true;
 }

--- a/1 - Aplicacao/Sistema.APP/DTOs/UsuarioDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/UsuarioDto.cs
@@ -5,5 +5,7 @@ public class UsuarioDto
     public int Id { get; set; }
     public string Nome { get; set; } = string.Empty;
     public string Cpf { get; set; } = string.Empty;
+    public bool Ativo { get; set; } = true;
+    public string SenhaHash { get; set; } = string.Empty;
     public int PerfilId { get; set; }
 }

--- a/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
+++ b/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
@@ -9,6 +9,9 @@ public class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<Perfil, PerfilDto>().ReverseMap();
-        CreateMap<Usuario, UsuarioDto>().ReverseMap();
+        CreateMap<Usuario, UsuarioDto>()
+            .ForMember(d => d.SenhaHash, o => o.MapFrom(s => s.SenhaHash))
+            .ForMember(d => d.Ativo, o => o.MapFrom(s => s.Ativo))
+            .ReverseMap();
     }
 }

--- a/2 - Dominio/Sistema.CORE/Entities/Perfil.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Perfil.cs
@@ -4,4 +4,5 @@ public class Perfil : AuditableEntity
 {
     public int Id { get; set; }
     public string Nome { get; set; } = string.Empty;
+    public bool Ativo { get; set; } = true;
 }

--- a/2 - Dominio/Sistema.CORE/Entities/Usuario.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Usuario.cs
@@ -5,6 +5,8 @@ public class Usuario : AuditableEntity
     public int Id { get; set; }
     public string Nome { get; set; } = string.Empty;
     public string Cpf { get; set; } = string.Empty;
+    public bool Ativo { get; set; } = true;
+    public string SenhaHash { get; set; } = string.Empty;
     public int PerfilId { get; set; }
     public Perfil? Perfil { get; set; }
 }

--- a/2 - Dominio/Sistema.CORE/Services/AuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/AuthService.cs
@@ -25,7 +25,7 @@ public class AuthService : IAuthService
     public async Task<string?> AuthenticateAsync(string cpf, string senha)
     {
         var user = await _uow.Usuarios.GetByCpfAsync(cpf);
-        if (user is null) return null;
+        if (user is null || !user.Ativo) return null;
         var result = _hasher.VerifyHashedPassword(user, user.SenhaHash, senha);
         if (result == PasswordVerificationResult.Failed) return null;
 

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminSeed.cs
@@ -8,6 +8,7 @@ public static class AdminSeed
     {
         Id = 1,
         Nome = "Admin",
-        UsuarioInclusao = "seed"
+        UsuarioInclusao = "seed",
+        Ativo = true
     };
 }


### PR DESCRIPTION
## Summary
- add `Ativo` and `SenhaHash` to `Usuario` entity
- add `Ativo` to `Perfil` entity
- expose new fields through DTOs and mapping profile
- validate `Ativo` in authentication
- seed `Admin` profile with `Ativo` flag

## Testing
- `dotnet build Sistema.sln -warnaserror` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d39e170832c8a9b8d6d8094283a