### PR TITLE
Renomear metodos para Buscar

### DIFF
--- a/0 - Apresentacao/Sistema.API/Controllers/AuthController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/AuthController.cs
@@ -20,7 +20,7 @@ public class AuthController : ControllerBase
     [HttpPost("login")]
     public async Task<ActionResult<string>> Login(LoginDto dto)
     {
-        var token = await _authService.AuthenticateAsync(dto.Cpf, dto.Senha);
+        var token = await _authService.AutenticarAsync(dto.Cpf, dto.Senha);
         if (token is null) return Unauthorized();
         return Ok(token);
     }

--- a/0 - Apresentacao/Sistema.API/Controllers/FuncionalidadeController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/FuncionalidadeController.cs
@@ -25,7 +25,7 @@ public class FuncionalidadeController : ControllerBase
     [HttpGet]
     public async Task<PagedResult<FuncionalidadeDto>> Get([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
-        var result = await _service.GetPagedAsync(page, pageSize);
+        var result = await _service.BuscarPaginadasAsync(page, pageSize);
         var items = _mapper.Map<IEnumerable<FuncionalidadeDto>>(result.Items);
         return new PagedResult<FuncionalidadeDto>(items, result.TotalCount, result.Page, result.PageSize);
     }
@@ -33,7 +33,7 @@ public class FuncionalidadeController : ControllerBase
     [HttpGet("{id}")]
     public async Task<ActionResult<FuncionalidadeDto>> Get(int id)
     {
-        var obj = await _service.GetByIdAsync(id);
+        var obj = await _service.BuscarPorIdAsync(id);
         if (obj is null) return NotFound();
         return _mapper.Map<FuncionalidadeDto>(obj);
     }
@@ -42,7 +42,7 @@ public class FuncionalidadeController : ControllerBase
     public async Task<ActionResult<FuncionalidadeDto>> Post(FuncionalidadeDto dto)
     {
         var entity = _mapper.Map<Funcionalidade>(dto);
-        var result = await _service.AddAsync(entity);
+        var result = await _service.AdicionarAsync(entity);
         return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<FuncionalidadeDto>(result.Data));
     }
 
@@ -51,14 +51,14 @@ public class FuncionalidadeController : ControllerBase
     {
         if (id != dto.Id) return BadRequest();
         var entity = _mapper.Map<Funcionalidade>(dto);
-        await _service.UpdateAsync(entity);
+        await _service.AtualizarAsync(entity);
         return NoContent();
     }
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {
-        await _service.DeleteAsync(id);
+        await _service.RemoverAsync(id);
         return NoContent();
     }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
@@ -20,6 +20,6 @@ public class LogController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo)
     {
-        return await _logs.GetFilteredAsync(inicio, fim, tipo);
+        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo);
     }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/PerfilController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/PerfilController.cs
@@ -22,14 +22,14 @@ public class PerfilController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<PerfilDto>> Get()
     {
-        var perfis = await _service.GetAllAsync();
+        var perfis = await _service.BuscarTodosAsync();
         return _mapper.Map<IEnumerable<PerfilDto>>(perfis);
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<PerfilDto>> Get(int id)
     {
-        var perfil = await _service.GetByIdAsync(id);
+        var perfil = await _service.BuscarPorIdAsync(id);
         if (perfil is null) return NotFound();
         return _mapper.Map<PerfilDto>(perfil);
     }
@@ -38,7 +38,7 @@ public class PerfilController : ControllerBase
     public async Task<ActionResult<PerfilDto>> Post(PerfilDto dto)
     {
         var perfil = _mapper.Map<Perfil>(dto); 
-        var result = await _service.AddAsync(perfil);
+        var result = await _service.AdicionarAsync(perfil);
         if (!result.Success) return BadRequest(result.Message);
         return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<PerfilDto>(result.Data)); 
     }
@@ -48,7 +48,7 @@ public class PerfilController : ControllerBase
     {
         if (id != dto.Id) return BadRequest();
         var perfil = _mapper.Map<Perfil>(dto); 
-        var result = await _service.UpdateAsync(perfil);
+        var result = await _service.AtualizarAsync(perfil);
         if (!result.Success) return BadRequest(result.Message); 
         return NoContent();
     }
@@ -56,7 +56,7 @@ public class PerfilController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     { 
-        var result = await _service.DeleteAsync(id);
+        var result = await _service.RemoverAsync(id);
         if (!result.Success) return BadRequest(result.Message); 
         return NoContent();
     }

--- a/0 - Apresentacao/Sistema.API/Controllers/UsuarioController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/UsuarioController.cs
@@ -23,14 +23,14 @@ public class UsuarioController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<UsuarioDto>> Get()
     {
-        var usuarios = await _service.GetAllAsync();
+        var usuarios = await _service.BuscarTodosAsync();
         return _mapper.Map<IEnumerable<UsuarioDto>>(usuarios);
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<UsuarioDto>> Get(int id)
     {
-        var usuario = await _service.GetByIdAsync(id);
+        var usuario = await _service.BuscarPorIdAsync(id);
         if (usuario is null) return NotFound();
         return _mapper.Map<UsuarioDto>(usuario);
     }
@@ -39,7 +39,7 @@ public class UsuarioController : ControllerBase
     public async Task<ActionResult<UsuarioDto>> Post(UsuarioDto dto)
     {
         var usuario = _mapper.Map<Usuario>(dto);
-        var result = await _service.AddAsync(usuario);
+        var result = await _service.AdicionarAsync(usuario);
         if (!result.Success) return BadRequest(result.Message);
         return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<UsuarioDto>(result.Data));
     }
@@ -49,7 +49,7 @@ public class UsuarioController : ControllerBase
     {
         if (id != dto.Id) return BadRequest();
         var usuario = _mapper.Map<Usuario>(dto);
-        var result = await _service.UpdateAsync(usuario);
+        var result = await _service.AtualizarAsync(usuario);
         if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }
@@ -57,7 +57,7 @@ public class UsuarioController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {
-        var result = await _service.DeleteAsync(id);
+        var result = await _service.RemoverAsync(id);
         if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }

--- a/2 - Dominio/Sistema.CORE/Interfaces/IFuncionalidadeRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/IFuncionalidadeRepository.cs
@@ -5,9 +5,9 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IFuncionalidadeRepository
 {
-    Task<PagedResult<Funcionalidade>> GetPagedAsync(int page, int pageSize);
-    Task<Funcionalidade?> GetByIdAsync(int id);
-    Task<Funcionalidade> AddAsync(Funcionalidade func);
-    Task UpdateAsync(Funcionalidade func);
-    Task DeleteAsync(int id);
+    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize);
+    Task<Funcionalidade?> BuscarPorIdAsync(int id);
+    Task<Funcionalidade> AdicionarAsync(Funcionalidade func);
+    Task AtualizarAsync(Funcionalidade func);
+    Task RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Interfaces/ILogRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/ILogRepository.cs
@@ -4,5 +4,5 @@ namespace Sistema.CORE.Interfaces;
 
 public interface ILogRepository
 {
-    Task AddAsync(Log log);
+    Task AdicionarAsync(Log log);
 }

--- a/2 - Dominio/Sistema.CORE/Interfaces/IPerfilFuncionalidadeRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/IPerfilFuncionalidadeRepository.cs
@@ -4,6 +4,6 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IPerfilFuncionalidadeRepository
 {
-    Task<IEnumerable<PerfilFuncionalidade>> GetByPerfilIdAsync(int perfilId);
-    Task SetForPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs);
+    Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId);
+    Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs);
 }

--- a/2 - Dominio/Sistema.CORE/Interfaces/IPerfilRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/IPerfilRepository.cs
@@ -5,11 +5,11 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IPerfilRepository
 {
-    Task<PagedResult<Perfil>> GetAllAsync(int page, int pageSize);
-    Task<PagedResult<Perfil>> GetFilteredAsync(bool? ativo, int page, int pageSize);
-    Task<Perfil?> GetByIdAsync(int id);
-    Task<Perfil?> GetByNameAsync(string nome);
-    Task<Perfil> AddAsync(Perfil perfil);
-    Task UpdateAsync(Perfil perfil);
-    Task DeleteAsync(int id);
+    Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize);
+    Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize);
+    Task<Perfil?> BuscarPorIdAsync(int id);
+    Task<Perfil?> BuscarPorNomeAsync(string nome);
+    Task<Perfil> AdicionarAsync(Perfil perfil);
+    Task AtualizarAsync(Perfil perfil);
+    Task RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Interfaces/IUnitOfWork.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/IUnitOfWork.cs
@@ -7,5 +7,5 @@ public interface IUnitOfWork
     IFuncionalidadeRepository Funcionalidades { get; }
     IPerfilFuncionalidadeRepository PerfilFuncionalidades { get; }
     ILogRepository Logs { get; }
-    Task<int> CommitAsync();
+    Task<int> ConfirmarAsync();
 }

--- a/2 - Dominio/Sistema.CORE/Interfaces/IUsuarioRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/IUsuarioRepository.cs
@@ -5,12 +5,12 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IUsuarioRepository
 {
-    Task<PagedResult<Usuario>> GetAllAsync(int page, int pageSize);
-    Task<PagedResult<Usuario>> GetFilteredAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize);
-    Task<Usuario?> GetByIdAsync(int id);
-    Task<Usuario?> GetByCpfAsync(string cpf);
-    Task<bool> ExistsActiveByPerfilAsync(int perfilId);
-    Task<Usuario> AddAsync(Usuario usuario);
-    Task UpdateAsync(Usuario usuario);
-    Task DeleteAsync(int id);
+    Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize);
+    Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize);
+    Task<Usuario?> BuscarPorIdAsync(int id);
+    Task<Usuario?> BuscarPorCpfAsync(string cpf);
+    Task<bool> ExisteAtivoPorPerfilAsync(int perfilId);
+    Task<Usuario> AdicionarAsync(Usuario usuario);
+    Task AtualizarAsync(Usuario usuario);
+    Task RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Services/AuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/AuthService.cs
@@ -22,18 +22,18 @@ public class AuthService : IAuthService
         _config = config;
     }
 
-    public async Task<string?> AuthenticateAsync(string cpf, string senha)
+    public async Task<string?> AutenticarAsync(string cpf, string senha)
     {
-        var user = await _uow.Usuarios.GetByCpfAsync(cpf);
-        if (user is null || !user.Ativo) return null;
-        var result = _hasher.VerifyHashedPassword(user, user.SenhaHash, senha);
-        if (result == PasswordVerificationResult.Failed) return null;
+        var usuario = await _uow.Usuarios.BuscarPorCpfAsync(cpf);
+        if (usuario is null || !usuario.Ativo) return null;
+        var resultado = _hasher.VerifyHashedPassword(usuario, usuario.SenhaHash, senha);
+        if (resultado == PasswordVerificationResult.Failed) return null;
 
-        var claims = new[]
+        var reivindicacoes = new[]
         {
-            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-            new Claim(ClaimTypes.Name, user.Nome),
-            new Claim("perfil", user.PerfilId.ToString())
+            new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString()),
+            new Claim(ClaimTypes.Name, usuario.Nome),
+            new Claim("perfil", usuario.PerfilId.ToString())
         };
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
@@ -41,7 +41,7 @@ public class AuthService : IAuthService
         var token = new JwtSecurityToken(
             issuer: _config["Jwt:Issuer"],
             audience: _config["Jwt:Audience"],
-            claims: claims,
+            claims: reivindicacoes,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);
 

--- a/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
@@ -13,29 +13,29 @@ public class FuncionalidadeService : IFuncionalidadeService
         _uow = uow;
     }
 
-    public Task<PagedResult<Funcionalidade>> GetPagedAsync(int page, int pageSize)
-        => _uow.Funcionalidades.GetPagedAsync(page, pageSize);
+    public Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize)
+        => _uow.Funcionalidades.BuscarPaginadasAsync(page, pageSize);
 
-    public Task<Funcionalidade?> GetByIdAsync(int id) => _uow.Funcionalidades.GetByIdAsync(id);
+    public Task<Funcionalidade?> BuscarPorIdAsync(int id) => _uow.Funcionalidades.BuscarPorIdAsync(id);
 
-    public async Task<OperationResult<Funcionalidade>> AddAsync(Funcionalidade func)
+    public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func)
     {
-        await _uow.Funcionalidades.AddAsync(func);
-        await _uow.CommitAsync();
+        await _uow.Funcionalidades.AdicionarAsync(func);
+        await _uow.ConfirmarAsync();
         return new OperationResult<Funcionalidade>(true, "Criado", func);
     }
 
-    public async Task<OperationResult> UpdateAsync(Funcionalidade func)
+    public async Task<OperationResult> AtualizarAsync(Funcionalidade func)
     {
-        await _uow.Funcionalidades.UpdateAsync(func);
-        await _uow.CommitAsync();
+        await _uow.Funcionalidades.AtualizarAsync(func);
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Atualizado");
     }
 
-    public async Task<OperationResult> DeleteAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id)
     {
-        await _uow.Funcionalidades.DeleteAsync(id);
-        await _uow.CommitAsync();
+        await _uow.Funcionalidades.RemoverAsync(id);
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/IAuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/IAuthService.cs
@@ -4,5 +4,5 @@ namespace Sistema.CORE.Services;
 
 public interface IAuthService
 {
-    Task<string?> AuthenticateAsync(string cpf, string senha);
+    Task<string?> AutenticarAsync(string cpf, string senha);
 }

--- a/2 - Dominio/Sistema.CORE/Services/IFuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/IFuncionalidadeService.cs
@@ -5,9 +5,9 @@ namespace Sistema.CORE.Services;
 
 public interface IFuncionalidadeService
 {
-    Task<PagedResult<Funcionalidade>> GetPagedAsync(int page, int pageSize);
-    Task<Funcionalidade?> GetByIdAsync(int id);
-    Task<OperationResult<Funcionalidade>> AddAsync(Funcionalidade func);
-    Task<OperationResult> UpdateAsync(Funcionalidade func);
-    Task<OperationResult> DeleteAsync(int id);
+    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize);
+    Task<Funcionalidade?> BuscarPorIdAsync(int id);
+    Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func);
+    Task<OperationResult> AtualizarAsync(Funcionalidade func);
+    Task<OperationResult> RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Services/IPerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/IPerfilService.cs
@@ -5,9 +5,9 @@ using Sistema.CORE.Common;
 
 public interface IPerfilService
 {
-    Task<IEnumerable<Perfil>> GetAllAsync();
-    Task<Perfil?> GetByIdAsync(int id);
-    Task<OperationResult<Perfil>> AddAsync(Perfil perfil);
-    Task<OperationResult> UpdateAsync(Perfil perfil);
-    Task<OperationResult> DeleteAsync(int id);
+    Task<IEnumerable<Perfil>> BuscarTodosAsync();
+    Task<Perfil?> BuscarPorIdAsync(int id);
+    Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil);
+    Task<OperationResult> AtualizarAsync(Perfil perfil);
+    Task<OperationResult> RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Services/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/IUsuarioService.cs
@@ -5,9 +5,9 @@ namespace Sistema.CORE.Services;
 
 public interface IUsuarioService
 {
-    Task<IEnumerable<Usuario>> GetAllAsync();
-    Task<Usuario?> GetByIdAsync(int id);
-    Task<OperationResult<Usuario>> AddAsync(Usuario usuario);
-    Task<OperationResult> UpdateAsync(Usuario usuario);
-    Task<OperationResult> DeleteAsync(int id);
+    Task<IEnumerable<Usuario>> BuscarTodosAsync();
+    Task<Usuario?> BuscarPorIdAsync(int id);
+    Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario);
+    Task<OperationResult> AtualizarAsync(Usuario usuario);
+    Task<OperationResult> RemoverAsync(int id);
 }

--- a/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
@@ -13,16 +13,16 @@ public class PerfilService : IPerfilService
         _uow = uow;
     }
 
-    public Task<IEnumerable<Perfil>> GetAllAsync() => _uow.Perfis.GetAllAsync();
+    public Task<IEnumerable<Perfil>> BuscarTodosAsync() => _uow.Perfis.BuscarTodosAsync();
 
-    public Task<Perfil?> GetByIdAsync(int id) => _uow.Perfis.GetByIdAsync(id);
+    public Task<Perfil?> BuscarPorIdAsync(int id) => _uow.Perfis.BuscarPorIdAsync(id);
 
-    public async Task<OperationResult<Perfil>> AddAsync(Perfil perfil)
+    public async Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil)
     {
-        var existing = await _uow.Perfis.GetByNameAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
         if (existing is not null)
         {
-            await _uow.Logs.AddAsync(new Log
+            await _uow.Logs.AdicionarAsync(new Log
             {
                 Entidade = nameof(Perfil),
                 Operacao = "Add",
@@ -31,12 +31,12 @@ public class PerfilService : IPerfilService
                 Tipo = LogTipo.Erro,
                 Usuario = perfil.UsuarioInclusao
             });
-            await _uow.CommitAsync();
+            await _uow.ConfirmarAsync();
             return new OperationResult<Perfil>(false, "Perfil já existe");
         }
 
-        var created = await _uow.Perfis.AddAsync(perfil);
-        await _uow.Logs.AddAsync(new Log
+        var created = await _uow.Perfis.AdicionarAsync(perfil);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Perfil),
             Operacao = "Add",
@@ -45,16 +45,16 @@ public class PerfilService : IPerfilService
             Tipo = LogTipo.Sucesso,
             Usuario = perfil.UsuarioInclusao
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult<Perfil>(true, "Perfil criado com sucesso", created);
     }
 
-    public async Task<OperationResult> UpdateAsync(Perfil perfil)
+    public async Task<OperationResult> AtualizarAsync(Perfil perfil)
     {
-        var existing = await _uow.Perfis.GetByNameAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
         if (existing is not null && existing.Id != perfil.Id)
         {
-            await _uow.Logs.AddAsync(new Log
+            await _uow.Logs.AdicionarAsync(new Log
             {
                 Entidade = nameof(Perfil),
                 Operacao = "Update",
@@ -63,12 +63,12 @@ public class PerfilService : IPerfilService
                 Tipo = LogTipo.Erro,
                 Usuario = perfil.UsuarioAlteracao ?? "system"
             });
-            await _uow.CommitAsync();
+            await _uow.ConfirmarAsync();
             return new OperationResult(false, "Nome já utilizado");
         }
 
-        await _uow.Perfis.UpdateAsync(perfil);
-        await _uow.Logs.AddAsync(new Log
+        await _uow.Perfis.AtualizarAsync(perfil);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Perfil),
             Operacao = "Update",
@@ -77,14 +77,14 @@ public class PerfilService : IPerfilService
             Tipo = LogTipo.Sucesso,
             Usuario = perfil.UsuarioAlteracao ?? "system"
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Perfil atualizado com sucesso");
     }
 
-    public async Task<OperationResult> DeleteAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id)
     {
-        await _uow.Perfis.DeleteAsync(id);
-        await _uow.Logs.AddAsync(new Log
+        await _uow.Perfis.RemoverAsync(id);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Perfil),
             Operacao = "Delete",
@@ -93,7 +93,7 @@ public class PerfilService : IPerfilService
             Tipo = LogTipo.Sucesso,
             Usuario = "system"
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Perfil removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -13,16 +13,16 @@ public class UsuarioService : IUsuarioService
         _uow = uow;
     }
 
-    public Task<IEnumerable<Usuario>> GetAllAsync() => _uow.Usuarios.GetAllAsync();
+    public Task<IEnumerable<Usuario>> BuscarTodosAsync() => _uow.Usuarios.BuscarTodosAsync();
 
-    public Task<Usuario?> GetByIdAsync(int id) => _uow.Usuarios.GetByIdAsync(id);
+    public Task<Usuario?> BuscarPorIdAsync(int id) => _uow.Usuarios.BuscarPorIdAsync(id);
 
-    public async Task<OperationResult<Usuario>> AddAsync(Usuario usuario)
+    public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario)
     {
-        var existing = await _uow.Usuarios.GetByCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
         if (existing is not null)
         {
-            await _uow.Logs.AddAsync(new Log
+            await _uow.Logs.AdicionarAsync(new Log
             {
                 Entidade = nameof(Usuario),
                 Operacao = "Add",
@@ -31,12 +31,12 @@ public class UsuarioService : IUsuarioService
                 Tipo = LogTipo.Erro,
                 Usuario = usuario.UsuarioInclusao
             });
-            await _uow.CommitAsync();
+            await _uow.ConfirmarAsync();
             return new OperationResult<Usuario>(false, "Usuário já existe");
         }
 
-        var created = await _uow.Usuarios.AddAsync(usuario);
-        await _uow.Logs.AddAsync(new Log
+        var created = await _uow.Usuarios.AdicionarAsync(usuario);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Usuario),
             Operacao = "Add",
@@ -45,16 +45,16 @@ public class UsuarioService : IUsuarioService
             Tipo = LogTipo.Sucesso,
             Usuario = usuario.UsuarioInclusao
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult<Usuario>(true, "Usuário criado com sucesso", created);
     }
 
-    public async Task<OperationResult> UpdateAsync(Usuario usuario)
+    public async Task<OperationResult> AtualizarAsync(Usuario usuario)
     {
-        var existing = await _uow.Usuarios.GetByCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
         if (existing is not null && existing.Id != usuario.Id)
         {
-            await _uow.Logs.AddAsync(new Log
+            await _uow.Logs.AdicionarAsync(new Log
             {
                 Entidade = nameof(Usuario),
                 Operacao = "Update",
@@ -63,12 +63,12 @@ public class UsuarioService : IUsuarioService
                 Tipo = LogTipo.Erro,
                 Usuario = usuario.UsuarioAlteracao ?? "system"
             });
-            await _uow.CommitAsync();
+            await _uow.ConfirmarAsync();
             return new OperationResult(false, "CPF já utilizado");
         }
 
-        await _uow.Usuarios.UpdateAsync(usuario);
-        await _uow.Logs.AddAsync(new Log
+        await _uow.Usuarios.AtualizarAsync(usuario);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Usuario),
             Operacao = "Update",
@@ -77,14 +77,14 @@ public class UsuarioService : IUsuarioService
             Tipo = LogTipo.Sucesso,
             Usuario = usuario.UsuarioAlteracao ?? "system"
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Usuário atualizado com sucesso");
     }
 
-    public async Task<OperationResult> DeleteAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id)
     {
-        await _uow.Usuarios.DeleteAsync(id);
-        await _uow.Logs.AddAsync(new Log
+        await _uow.Usuarios.RemoverAsync(id);
+        await _uow.Logs.AdicionarAsync(new Log
         {
             Entidade = nameof(Usuario),
             Operacao = "Delete",
@@ -93,7 +93,7 @@ public class UsuarioService : IUsuarioService
             Tipo = LogTipo.Sucesso,
             Usuario = "system"
         });
-        await _uow.CommitAsync();
+        await _uow.ConfirmarAsync();
         return new OperationResult(true, "Usuário removido");
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/FuncionalidadeRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/FuncionalidadeRepository.cs
@@ -15,31 +15,31 @@ public class FuncionalidadeRepository : IFuncionalidadeRepository
         _context = context;
     }
 
-    public Task<Funcionalidade> AddAsync(Funcionalidade func)
+    public Task<Funcionalidade> AdicionarAsync(Funcionalidade func)
     {
         _context.Funcionalidades.Add(func);
         return Task.FromResult(func);
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task RemoverAsync(int id)
     {
         var obj = await _context.Funcionalidades.FindAsync(id);
         if (obj is null) return;
         _context.Funcionalidades.Remove(obj);
     }
 
-    public async Task<Funcionalidade?> GetByIdAsync(int id)
+    public async Task<Funcionalidade?> BuscarPorIdAsync(int id)
     {
         return await _context.Funcionalidades.FindAsync(id);
     }
 
-    public Task UpdateAsync(Funcionalidade func)
+    public Task AtualizarAsync(Funcionalidade func)
     {
         _context.Funcionalidades.Update(func);
         return Task.CompletedTask;
     }
 
-    public async Task<PagedResult<Funcionalidade>> GetPagedAsync(int page, int pageSize)
+    public async Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize)
     {
         var query = _context.Funcionalidades.AsNoTracking().OrderBy(f => f.Id);
         return await query.ToPagedResultAsync(page, pageSize);

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
@@ -15,13 +15,13 @@ public class LogRepository : ILogRepository
         _context = context;
     }
 
-    public Task AddAsync(Log log)
+    public Task AdicionarAsync(Log log)
     {
         _context.Logs.Add(log);
         return Task.CompletedTask;
     } 
 
-    public async Task<IEnumerable<Log>> GetFilteredAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo)
+    public async Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo)
     {
         var query = _context.Logs.AsQueryable();
         if (inicio.HasValue)

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilFuncionalidadeRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilFuncionalidadeRepository.cs
@@ -14,7 +14,7 @@ public class PerfilFuncionalidadeRepository : IPerfilFuncionalidadeRepository
         _context = context;
     }
 
-    public async Task<IEnumerable<PerfilFuncionalidade>> GetByPerfilIdAsync(int perfilId)
+    public async Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId)
     {
         return await _context.PerfilFuncionalidades
             .Include(pf => pf.Funcionalidade)
@@ -23,7 +23,7 @@ public class PerfilFuncionalidadeRepository : IPerfilFuncionalidadeRepository
             .ToListAsync();
     }
 
-    public async Task SetForPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs)
+    public async Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs)
     {
         var existing = _context.PerfilFuncionalidades.Where(pf => pf.PerfilId == perfilId);
         _context.PerfilFuncionalidades.RemoveRange(existing);

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilRepository.cs
@@ -16,26 +16,26 @@ public class PerfilRepository : IPerfilRepository
         _context = context;
     }
 
-    public Task<Perfil> AddAsync(Perfil perfil)
+    public Task<Perfil> AdicionarAsync(Perfil perfil)
     {
         _context.Perfis.Add(perfil);
         return Task.FromResult(perfil);
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task RemoverAsync(int id)
     {
         var perfil = await _context.Perfis.FindAsync(id);
         if (perfil is null) return;
         _context.Perfis.Remove(perfil);
     }
  
-    public Task<PagedResult<Perfil>> GetAllAsync(int page, int pageSize)
+    public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize)
     {
         var query = _context.Perfis.AsNoTracking().OrderBy(p => p.Id);
         return query.ToPagedResultAsync(page, pageSize);
     }
 
-    public Task<PagedResult<Perfil>> GetFilteredAsync(bool? ativo, int page, int pageSize)
+    public Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize)
     {
         var query = _context.Perfis.AsQueryable();
         if (ativo.HasValue)
@@ -46,17 +46,17 @@ public class PerfilRepository : IPerfilRepository
         return query.ToPagedResultAsync(page, pageSize); 
     }
 
-    public async Task<Perfil?> GetByNameAsync(string nome)
+    public async Task<Perfil?> BuscarPorNomeAsync(string nome)
     {
         return await _context.Perfis.FirstOrDefaultAsync(p => p.Nome == nome);
     } 
     
-    public async Task<Perfil?> GetByIdAsync(int id)
+    public async Task<Perfil?> BuscarPorIdAsync(int id)
     {
         return await _context.Perfis.FindAsync(id);
     }
 
-    public Task UpdateAsync(Perfil perfil)
+    public Task AtualizarAsync(Perfil perfil)
     {
         _context.Perfis.Update(perfil);
         return Task.CompletedTask;

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
@@ -16,26 +16,26 @@ public class UsuarioRepository : IUsuarioRepository
         _context = context;
     }
 
-    public Task<Usuario> AddAsync(Usuario usuario)
+    public Task<Usuario> AdicionarAsync(Usuario usuario)
     {
         _context.Usuarios.Add(usuario);
         return Task.FromResult(usuario);
     }
 
-    public async Task DeleteAsync(int id)
+    public async Task RemoverAsync(int id)
     {
         var usuario = await _context.Usuarios.FindAsync(id);
         if (usuario is null) return;
         _context.Usuarios.Remove(usuario);
     }
  
-    public Task<PagedResult<Usuario>> GetAllAsync(int page, int pageSize)
+    public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize)
     {
         var query = _context.Usuarios.AsNoTracking().OrderBy(u => u.Id);
         return query.ToPagedResultAsync(page, pageSize);
     }
 
-    public Task<PagedResult<Usuario>> GetFilteredAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize)
+    public Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize)
     {
         var query = _context.Usuarios.AsQueryable();
         if (inicio.HasValue)
@@ -50,22 +50,22 @@ public class UsuarioRepository : IUsuarioRepository
         return query.ToPagedResultAsync(page, pageSize);
     }
 
-    public async Task<bool> ExistsActiveByPerfilAsync(int perfilId)
+    public async Task<bool> ExisteAtivoPorPerfilAsync(int perfilId)
     {
         return await _context.Usuarios.AnyAsync(u => u.PerfilId == perfilId && u.Ativo);
     }
 
-    public async Task<Usuario?> GetByCpfAsync(string cpf)
+    public async Task<Usuario?> BuscarPorCpfAsync(string cpf)
     {
         return await _context.Usuarios.FirstOrDefaultAsync(u => u.Cpf == cpf);
     }
 
-    public async Task<Usuario?> GetByIdAsync(int id)
+    public async Task<Usuario?> BuscarPorIdAsync(int id)
     {
         return await _context.Usuarios.FindAsync(id);
     }
 
-    public Task UpdateAsync(Usuario usuario)
+    public Task AtualizarAsync(Usuario usuario)
     {
         _context.Usuarios.Update(usuario);
         return Task.CompletedTask;

--- a/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
@@ -27,5 +27,5 @@ public class UnitOfWork : IUnitOfWork
         PerfilFuncionalidades = perfilFuncs; 
     }
 
-    public Task<int> CommitAsync() => _context.SaveChangesAsync();
+    public Task<int> ConfirmarAsync() => _context.SaveChangesAsync();
 }


### PR DESCRIPTION
## Summary
- rename API methods from `Obter*` to `Buscar*`
- rename service and repository methods accordingly

## Testing
- `dotnet build Sistema.sln -c Release` *(fails to restore Microsoft.AspNetCore.Identity)*

------
https://chatgpt.com/codex/tasks/task_e_688a29216840832c852efad1c8156783