### PR TITLE
Fix missing method in log repository interface

### DIFF
--- a/2 - Dominio/Sistema.CORE/Interfaces/ILogRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Interfaces/ILogRepository.cs
@@ -5,4 +5,5 @@ namespace Sistema.CORE.Interfaces;
 public interface ILogRepository
 {
     Task AdicionarAsync(Log log);
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo);
 }


### PR DESCRIPTION
## Summary
- add missing `BuscarFiltradosAsync` method to `ILogRepository`

## Testing
- `dotnet build Sistema.sln -c Release` *(fails: Unable to find package Microsoft.AspNetCore.Identity)*

------
https://chatgpt.com/codex/tasks/task_e_688bad704584832cb8b11ebeb9cf148e