### PR TITLE
Switch to Scalar UI for Swagger docs

### DIFF
--- a/0 - Apresentacao/Sistema.API/Program.cs
+++ b/0 - Apresentacao/Sistema.API/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Serilog;
+using AspNetCore.Scalar;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,7 +41,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseScalar();
 }
 
 app.UseAuthentication();

--- a/0 - Apresentacao/Sistema.API/Properties/launchSettings.json
+++ b/0 - Apresentacao/Sistema.API/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar-api-docs",
       "applicationUrl": "http://localhost:5057",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -22,7 +22,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar-api-docs",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/0 - Apresentacao/Sistema.API/Sistema.API.csproj
+++ b/0 - Apresentacao/Sistema.API/Sistema.API.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+    <PackageReference Include="AspNetCore.Scalar" Version="1.1.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- integrate AspNetCore.Scalar package
- replace SwaggerUI with Scalar in Program.cs
- adjust launch URL for Scalar docs

## Testing
- `dotnet restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd734410832cbc97c1d810a9931d