### PR TITLE
Add API login with iziToast and iziModal integration

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
@@ -23,11 +23,11 @@ public class AccountController : Controller
     }
 
     [HttpPost]
-    public async Task<IActionResult> Login(LoginViewModel model)
+    public async Task<IActionResult> Login([FromBody] LoginViewModel model)
     {
         if (!ModelState.IsValid)
         {
-            return View(model);
+            return BadRequest(ModelState);
         }
 
         try
@@ -38,7 +38,7 @@ public class AccountController : Controller
             {
                 var token = await response.Content.ReadAsStringAsync();
                 HttpContext.Session.SetString("AuthToken", token.Trim('"'));
-                return RedirectToAction("Index", "Home");
+                return Ok(new { success = true });
             }
         }
         catch (Exception ex)
@@ -46,8 +46,7 @@ public class AccountController : Controller
             _logger.LogError(ex, "Erro ao autenticar");
         }
 
-        ModelState.AddModelError(string.Empty, "Credenciais inválidas");
-        return View(model);
+        return Unauthorized(new { message = "Credenciais inválidas" });
     }
 
     [HttpGet]

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/login.css" asp-append-version="true" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast@1.4.0/dist/css/iziToast.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izimodal/css/iziModal.min.css" />
 </head>
 <body>
     <div class="container-fluid login-container">
@@ -25,7 +27,7 @@
                 <div class="w-100" style="max-width: 330px;">
                     <h2 class="mb-4 text-center">@ViewData["Title"]</h2>
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    <form asp-action="Login" method="post">
+                    <form asp-action="Login" method="post" id="loginForm">
                         <div class="mb-3">
                             <label asp-for="Cpf" class="form-label"></label>
                             <input asp-for="Cpf" class="form-control" />
@@ -44,8 +46,13 @@
     </div>
 
     <script src="~/lib/jquery/dist/jquery.js"></script>
+    <div id="loadingModal"></div>
+
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/izitoast@1.4.0/dist/js/iziToast.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/izimodal/js/iziModal.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/login.js" asp-append-version="true"></script>
     @await Html.PartialAsync("_ValidationScriptsPartial")
 </body>
 </html>

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/Sistema.MVC.styles.css" asp-append-version="true" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast@1.4.0/dist/css/iziToast.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izimodal/css/iziModal.min.css" />
 </head>
 <body>
     <header>
@@ -55,6 +57,8 @@
     </footer>
     <script src="~/lib/jquery/dist/jquery.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/izitoast@1.4.0/dist/js/iziToast.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/izimodal/js/iziModal.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/login.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/login.js
@@ -1,0 +1,41 @@
+$(function () {
+    $('#loginForm').on('submit', async function (e) {
+        e.preventDefault();
+        const modal = $('#loadingModal');
+        modal.iziModal({ title: 'Aguarde', subtitle: 'Autenticando...', close: false });
+        modal.iziModal('open');
+        showInfo('Enviando dados');
+
+        const data = {
+            cpf: $('#Cpf').val(),
+            senha: $('#Senha').val()
+        };
+
+        try {
+            const response = await fetch('/Account/Login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+
+            modal.iziModal('close');
+
+            if (response.ok) {
+                showSuccess('Login realizado');
+                setTimeout(() => { window.location.href = '/'; }, 1500);
+            } else if (response.status === 400) {
+                showWarning('Preencha os campos corretamente');
+            } else {
+                let msg = 'Credenciais inválidas';
+                try {
+                    const err = await response.json();
+                    if (err.message) msg = err.message;
+                } catch { }
+                showError(msg);
+            }
+        } catch {
+            modal.iziModal('close');
+            showError('Falha na comunicação');
+        }
+    });
+});

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -2,3 +2,19 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+function showSuccess(message) {
+    iziToast.success({ title: 'Sucesso', message });
+}
+
+function showError(message) {
+    iziToast.error({ title: 'Erro', message });
+}
+
+function showWarning(message) {
+    iziToast.warning({ title: 'Alerta', message });
+}
+
+function showInfo(message) {
+    iziToast.info({ title: 'Info', message });
+}


### PR DESCRIPTION
## Summary
- Add AJAX login consuming API and returning JSON
- Integrate iziToast for success, error, warning and info messages
- Use iziModal for loading modal during login

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cbd625004832c98dc3d2f1c0ff862