### PR TITLE
feat: add registration and password recovery with email

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
@@ -1,18 +1,29 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Sistema.CORE.Entities;
+using Sistema.CORE.Interfaces;
 using Sistema.MVC.Models;
-using System.Net.Http.Json;
 
 namespace Sistema.MVC.Controllers;
 
 public class AccountController : Controller
 {
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IAuthService _authService;
+    private readonly IUsuarioService _usuarioService;
+    private readonly IPasswordHasher<Usuario> _hasher;
+    private readonly IEmailService _emailService;
     private readonly ILogger<AccountController> _logger;
 
-    public AccountController(IHttpClientFactory httpClientFactory,
+    public AccountController(IAuthService authService,
+        IUsuarioService usuarioService,
+        IPasswordHasher<Usuario> hasher,
+        IEmailService emailService,
         ILogger<AccountController> logger)
     {
-        _httpClientFactory = httpClientFactory;
+        _authService = authService;
+        _usuarioService = usuarioService;
+        _hasher = hasher;
+        _emailService = emailService;
         _logger = logger;
     }
 
@@ -32,12 +43,10 @@ public class AccountController : Controller
 
         try
         {
-            var client = _httpClientFactory.CreateClient("Api");
-            var response = await client.PostAsJsonAsync("api/auth/login", model);
-            if (response.IsSuccessStatusCode)
+            var token = await _authService.AutenticarAsync(model.Cpf, model.Senha);
+            if (token is not null)
             {
-                var token = await response.Content.ReadAsStringAsync();
-                HttpContext.Session.SetString("AuthToken", token.Trim('"'));
+                HttpContext.Session.SetString("AuthToken", token);
                 return Ok(new { success = true });
             }
         }
@@ -47,6 +56,73 @@ public class AccountController : Controller
         }
 
         return Unauthorized(new { message = "Credenciais inválidas" });
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Register([FromBody] RegisterViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        try
+        {
+            var usuario = new Usuario
+            {
+                Nome = model.Nome,
+                Cpf = model.Cpf,
+                PerfilId = 2,
+                UsuarioInclusao = model.Cpf,
+                Ativo = true
+            };
+            usuario.SenhaHash = _hasher.HashPassword(usuario, model.Senha);
+            var result = await _usuarioService.AdicionarAsync(usuario);
+            if (result.Success)
+            {
+                await _emailService.EnviarAsync(model.Email, "Bem-vindo", $"Sua senha é: {model.Senha}");
+                return Ok(new { success = true });
+            }
+            return BadRequest(new { message = result.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao registrar");
+            return StatusCode(500, new { message = "Erro ao registrar" });
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> RecuperarSenha([FromBody] ForgotPasswordViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        try
+        {
+            var usuario = await _usuarioService.BuscarPorCpfAsync(model.Cpf);
+            if (usuario is null)
+            {
+                return NotFound(new { message = "Usuário não encontrado" });
+            }
+            var novaSenha = Guid.NewGuid().ToString("N").Substring(0, 8);
+            usuario.SenhaHash = _hasher.HashPassword(usuario, novaSenha);
+            usuario.UsuarioAlteracao = "system";
+            var result = await _usuarioService.AtualizarAsync(usuario);
+            if (result.Success)
+            {
+                await _emailService.EnviarAsync(model.Email, "Recuperação de Senha", $"Sua nova senha é: {novaSenha}");
+                return Ok(new { success = true });
+            }
+            return BadRequest(new { message = result.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao recuperar senha");
+            return StatusCode(500, new { message = "Erro ao recuperar senha" });
+        }
     }
 
     [HttpGet]

--- a/0 - Apresentacao/Sistema.MVC/Models/ForgotPasswordViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/ForgotPasswordViewModel.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sistema.MVC.Models;
+
+public class ForgotPasswordViewModel
+{
+    [Required]
+    [Display(Name = "CPF")]
+    public string Cpf { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+}

--- a/0 - Apresentacao/Sistema.MVC/Models/RegisterViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/RegisterViewModel.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sistema.MVC.Models;
+
+public class RegisterViewModel
+{
+    [Required]
+    [Display(Name = "Nome")]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required]
+    [Display(Name = "CPF")]
+    public string Cpf { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    [Display(Name = "Senha")]
+    public string Senha { get; set; } = string.Empty;
+}

--- a/0 - Apresentacao/Sistema.MVC/Program.cs
+++ b/0 - Apresentacao/Sistema.MVC/Program.cs
@@ -1,11 +1,12 @@
+using Sistema.APP;
+using Sistema.INFRA;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
-builder.Services.AddHttpClient("Api", c =>
-{
-    c.BaseAddress = new Uri(builder.Configuration["Api:BaseAddress"]!);
-});
+builder.Services.AddInfraestrutura();
+builder.Services.AddAplicacao();
 builder.Services.AddSession();
 
 var app = builder.Build();

--- a/0 - Apresentacao/Sistema.MVC/Sistema.MVC.csproj
+++ b/0 - Apresentacao/Sistema.MVC/Sistema.MVC.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\1 - Aplicacao\Sistema.APP\Sistema.APP.csproj" />
+    <ProjectReference Include="..\..\3 - Infraestrutura\Sistema.INFRA\Sistema.INFRA.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
@@ -40,6 +40,10 @@
                         </div>
                         <button type="submit" class="btn btn-primary w-100">Entrar</button>
                     </form>
+                    <div class="mt-3 text-center">
+                        <a href="#" id="forgotLink">Esqueci minha senha</a> |
+                        <a href="#" id="registerLink">Cadastrar</a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -54,5 +58,11 @@
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/login.js" asp-append-version="true"></script>
     @await Html.PartialAsync("_ValidationScriptsPartial")
+    <div id="registerModal" style="display:none">
+        @await Html.PartialAsync("_RegisterPartial", new Sistema.MVC.Models.RegisterViewModel())
+    </div>
+    <div id="forgotModal" style="display:none">
+        @await Html.PartialAsync("_ForgotPasswordPartial", new Sistema.MVC.Models.ForgotPasswordViewModel())
+    </div>
 </body>
 </html>

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/_ForgotPasswordPartial.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/_ForgotPasswordPartial.cshtml
@@ -1,0 +1,14 @@
+@model Sistema.MVC.Models.ForgotPasswordViewModel
+<form id="forgotForm">
+    <div class="mb-3">
+        <label asp-for="Cpf" class="form-label"></label>
+        <input asp-for="Cpf" class="form-control" id="RecCpf" />
+        <span asp-validation-for="Cpf" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" id="RecEmail" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Enviar</button>
+</form>

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/_RegisterPartial.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/_RegisterPartial.cshtml
@@ -1,0 +1,24 @@
+@model Sistema.MVC.Models.RegisterViewModel
+<form id="registerForm">
+    <div class="mb-3">
+        <label asp-for="Nome" class="form-label"></label>
+        <input asp-for="Nome" class="form-control" id="RegNome" />
+        <span asp-validation-for="Nome" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Cpf" class="form-label"></label>
+        <input asp-for="Cpf" class="form-control" id="RegCpf" />
+        <span asp-validation-for="Cpf" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" id="RegEmail" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Senha" class="form-label"></label>
+        <input asp-for="Senha" class="form-control" id="RegSenha" />
+        <span asp-validation-for="Senha" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Cadastrar</button>
+</form>

--- a/0 - Apresentacao/Sistema.MVC/appsettings.Development.json
+++ b/0 - Apresentacao/Sistema.MVC/appsettings.Development.json
@@ -7,5 +7,12 @@
   },
   "Api": {
     "BaseAddress": "http://localhost:5057"
+  },
+  "Smtp": {
+    "Host": "smtp.example.com",
+    "Port": "587",
+    "Username": "usuario@example.com",
+    "Password": "senha",
+    "From": "noreply@example.com"
   }
 }

--- a/0 - Apresentacao/Sistema.MVC/appsettings.json
+++ b/0 - Apresentacao/Sistema.MVC/appsettings.json
@@ -9,4 +9,11 @@
   ,"Api": {
     "BaseAddress": "http://localhost:5057"
   }
+  ,"Smtp": {
+    "Host": "smtp.example.com",
+    "Port": "587",
+    "Username": "usuario@example.com",
+    "Password": "senha",
+    "From": "noreply@example.com"
+  }
 }

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/login.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/login.js
@@ -38,4 +38,66 @@ $(function () {
             showError('Falha na comunicação');
         }
     });
+
+    $('#registerLink').on('click', function (e) {
+        e.preventDefault();
+        $('#registerModal').iziModal({ title: 'Cadastro' });
+        $('#registerModal').iziModal('open');
+    });
+
+    $('#forgotLink').on('click', function (e) {
+        e.preventDefault();
+        $('#forgotModal').iziModal({ title: 'Recuperar senha' });
+        $('#forgotModal').iziModal('open');
+    });
+
+    $('#registerForm').on('submit', async function (e) {
+        e.preventDefault();
+        const data = {
+            nome: $('#RegNome').val(),
+            cpf: $('#RegCpf').val(),
+            email: $('#RegEmail').val(),
+            senha: $('#RegSenha').val()
+        };
+        try {
+            const response = await fetch('/Account/Register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (response.ok) {
+                $('#registerModal').iziModal('close');
+                showSuccess('Cadastro realizado');
+            } else {
+                showError('Erro ao cadastrar');
+            }
+        } catch {
+            showError('Falha na comunicação');
+        }
+    });
+
+    $('#forgotForm').on('submit', async function (e) {
+        e.preventDefault();
+        const data = {
+            cpf: $('#RecCpf').val(),
+            email: $('#RecEmail').val()
+        };
+        try {
+            const response = await fetch('/Account/RecuperarSenha', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (response.ok) {
+                $('#forgotModal').iziModal('close');
+                showSuccess('Email enviado');
+            } else if (response.status === 404) {
+                showError('Usuário não encontrado');
+            } else {
+                showError('Erro ao enviar email');
+            }
+        } catch {
+            showError('Falha na comunicação');
+        }
+    });
 });

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IEmailService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IEmailService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Sistema.CORE.Interfaces;
+
+public interface IEmailService
+{
+    Task EnviarAsync(string destinatario, string assunto, string mensagem);
+}

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
@@ -7,6 +7,7 @@ public interface IUsuarioService
 {
     Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize);
     Task<Usuario?> BuscarPorIdAsync(int id);
+    Task<Usuario?> BuscarPorCpfAsync(string cpf);
     Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario);
     Task<OperationResult> AtualizarAsync(Usuario usuario);
     Task<OperationResult> RemoverAsync(int id);

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -13,10 +13,12 @@ public class UsuarioService : IUsuarioService
         _uow = uow;
     }
 
-public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize) =>
-    _uow.Usuarios.BuscarTodosAsync(page, pageSize);
+    public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize) =>
+        _uow.Usuarios.BuscarTodosAsync(page, pageSize);
 
     public Task<Usuario?> BuscarPorIdAsync(int id) => _uow.Usuarios.BuscarPorIdAsync(id);
+
+    public Task<Usuario?> BuscarPorCpfAsync(string cpf) => _uow.Usuarios.BuscarPorCpfAsync(cpf);
 
     public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario)
     {

--- a/2 - Dominio/Sistema.CORE/Sistema.CORE.csproj
+++ b/2 - Dominio/Sistema.CORE/Sistema.CORE.csproj
@@ -14,10 +14,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\3 - Infraestrutura\Sistema.INFRA\Sistema.INFRA.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
@@ -1,8 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Sistema.CORE.Interfaces;
-using Sistema.INFRA.Data; 
+using Sistema.INFRA.Data;
 using Sistema.INFRA.Repositories;
+using Sistema.INFRA.Services;
 
 namespace Sistema.INFRA;
 
@@ -14,10 +15,11 @@ public static class ServiceCollectionExtensions
             options.UseInMemoryDatabase("SistemaDB"));
         services.AddScoped<IPerfilRepository, PerfilRepository>();
         services.AddScoped<IUsuarioRepository, UsuarioRepository>();
-        services.AddScoped<ILogRepository, LogRepository>(); 
+        services.AddScoped<ILogRepository, LogRepository>();
         services.AddScoped<IFuncionalidadeRepository, FuncionalidadeRepository>();
         services.AddScoped<IPerfilFuncionalidadeRepository, PerfilFuncionalidadeRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
+        services.AddScoped<IEmailService, EmailService>();
  
         return services;
     }

--- a/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.Configuration;
+using Sistema.CORE.Interfaces;
+
+namespace Sistema.INFRA.Services;
+
+public class EmailService : IEmailService
+{
+    private readonly IConfiguration _config;
+
+    public EmailService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public async Task EnviarAsync(string destinatario, string assunto, string mensagem)
+    {
+        var host = _config["Smtp:Host"];
+        var portStr = _config["Smtp:Port"];
+        int port = 25;
+        if (!string.IsNullOrEmpty(portStr) && int.TryParse(portStr, out var parsed))
+        {
+            port = parsed;
+        }
+        var user = _config["Smtp:Username"];
+        var pass = _config["Smtp:Password"];
+        var from = _config["Smtp:From"];
+
+        using var client = new SmtpClient(host, port)
+        {
+            Credentials = new NetworkCredential(user, pass),
+            EnableSsl = true
+        };
+        using var mail = new MailMessage(from!, destinatario, assunto, mensagem);
+        await client.SendMailAsync(mail);
+    }
+}


### PR DESCRIPTION
## Summary
- connect MVC directly to application services for login
- implement user registration and password recovery flows
- add email service and modal partials for registration and password reset

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cc29d0994832ca4b88c5a10e9ea11