### PR TITLE
Add Fluent API mappings in infrastructure

### DIFF
--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
@@ -18,6 +18,12 @@ public class AppDbContext : DbContext
     public DbSet<PerfilFuncionalidade> PerfilFuncionalidades => Set<PerfilFuncionalidade>();
     public DbSet<Layout> Layouts => Set<Layout>();
 
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+
     public override int SaveChanges()
     {
         UpdateAuditFields();

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/FuncionalidadeMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/FuncionalidadeMap.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class FuncionalidadeMap : IEntityTypeConfiguration<Funcionalidade>
+{
+    public void Configure(EntityTypeBuilder<Funcionalidade> builder)
+    {
+        builder.ToTable("Funcionalidade");
+        builder.HasKey(f => f.Id);
+        builder.Property(f => f.Nome).IsRequired();
+        builder.Property(f => f.Ativo).HasDefaultValue(true);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/LayoutMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/LayoutMap.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class LayoutMap : IEntityTypeConfiguration<Layout>
+{
+    public void Configure(EntityTypeBuilder<Layout> builder)
+    {
+        builder.ToTable("Layout");
+        builder.HasKey(l => l.Id);
+        builder.Property(l => l.CorPrimaria).IsRequired();
+        builder.Property(l => l.ModoEscuro).HasDefaultValue(false);
+
+        builder.HasOne(l => l.Usuario)
+               .WithOne()
+               .HasForeignKey<Layout>(l => l.UsuarioId);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class LogMap : IEntityTypeConfiguration<Log>
+{
+    public void Configure(EntityTypeBuilder<Log> builder)
+    {
+        builder.ToTable("Log");
+        builder.HasKey(l => l.Id);
+        builder.Property(l => l.Entidade).IsRequired();
+        builder.Property(l => l.Operacao).IsRequired();
+        builder.Property(l => l.Mensagem).IsRequired();
+        builder.Property(l => l.Usuario).IsRequired();
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilFuncionalidadeMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilFuncionalidadeMap.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class PerfilFuncionalidadeMap : IEntityTypeConfiguration<PerfilFuncionalidade>
+{
+    public void Configure(EntityTypeBuilder<PerfilFuncionalidade> builder)
+    {
+        builder.ToTable("PerfilFuncionalidade");
+        builder.HasKey(pf => new { pf.PerfilId, pf.FuncionalidadeId });
+
+        builder.HasOne(pf => pf.Perfil)
+               .WithMany()
+               .HasForeignKey(pf => pf.PerfilId);
+
+        builder.HasOne(pf => pf.Funcionalidade)
+               .WithMany(f => f.Perfis)
+               .HasForeignKey(pf => pf.FuncionalidadeId);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilMap.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class PerfilMap : IEntityTypeConfiguration<Perfil>
+{
+    public void Configure(EntityTypeBuilder<Perfil> builder)
+    {
+        builder.ToTable("Perfil");
+        builder.HasKey(p => p.Id);
+        builder.Property(p => p.Nome).IsRequired();
+        builder.Property(p => p.Ativo).HasDefaultValue(true);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class UsuarioMap : IEntityTypeConfiguration<Usuario>
+{
+    public void Configure(EntityTypeBuilder<Usuario> builder)
+    {
+        builder.ToTable("Usuario");
+        builder.HasKey(u => u.Id);
+        builder.Property(u => u.Nome).IsRequired();
+        builder.Property(u => u.Cpf).IsRequired();
+        builder.Property(u => u.SenhaHash).IsRequired();
+        builder.Property(u => u.Ativo).HasDefaultValue(true);
+
+        builder.HasOne(u => u.Perfil)
+               .WithMany()
+               .HasForeignKey(u => u.PerfilId);
+    }
+}


### PR DESCRIPTION
## Summary
- add Mapping folder with Fluent API configurations for core entities
- configure AppDbContext to apply entity mappings

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cdbbdde38832c9b1caf6a29d43b4c