### PR TITLE
Atualiza dependências e remove pacote incompatível

### DIFF
--- a/0 - Apresentacao/Sistema.API/Program.cs
+++ b/0 - Apresentacao/Sistema.API/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Serilog;
-using AspNetCore.Scalar;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,7 +40,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseScalar();
+    app.UseSwaggerUI();
 }
 
 app.UseAuthentication();

--- a/0 - Apresentacao/Sistema.API/Sistema.API.csproj
+++ b/0 - Apresentacao/Sistema.API/Sistema.API.csproj
@@ -7,11 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-    <PackageReference Include="AspNetCore.Scalar" Version="1.1.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />

--- a/3 - Infraestrutura/Sistema.INFRA/Sistema.INFRA.csproj
+++ b/3 - Infraestrutura/Sistema.INFRA/Sistema.INFRA.csproj
@@ -5,9 +5,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Resumo
- Atualiza Entity Framework Core para 8.0.6
- Alinha AutoMapper com versão 12.0.1 e remove AspNetCore.Scalar
- Substitui `UseScalar` por `UseSwaggerUI`

## Testes
- `~/.dotnet/dotnet restore`
- `~/.dotnet/dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689d00db8390832c9504ad92021b0dfe