### PR TITLE
Add configurable settings entity with repository and service

### DIFF
--- a/1 - Aplicacao/Sistema.APP/ServiceCollectionExtensions.cs
+++ b/1 - Aplicacao/Sistema.APP/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUsuarioService, UsuarioService>();
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped<ITemaService, TemaService>();
+        services.AddScoped<IConfiguracaoService, ConfiguracaoService>();
         services.AddScoped<IPasswordHasher<Usuario>, PasswordHasher<Usuario>>();
         services.AddAutoMapper(typeof(MappingProfile));
         return services;

--- a/2 - Dominio/Sistema.CORE/Entities/Configuracao.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Configuracao.cs
@@ -1,0 +1,12 @@
+namespace Sistema.CORE.Entities;
+
+public class Configuracao : AuditableEntity
+{
+    public int Id { get; set; }
+    public string Agrupamento { get; set; } = string.Empty;
+    public string Chave { get; set; } = string.Empty;
+    public string Valor { get; set; } = string.Empty;
+    public ConfiguracaoTipo Tipo { get; set; }
+    public string? Descricao { get; set; }
+    public bool Ativo { get; set; } = true;
+}

--- a/2 - Dominio/Sistema.CORE/Entities/ConfiguracaoTipo.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/ConfiguracaoTipo.cs
@@ -1,0 +1,9 @@
+namespace Sistema.CORE.Entities;
+
+public enum ConfiguracaoTipo
+{
+    Texto,
+    Email,
+    Password,
+    Url
+}

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IConfiguracaoRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IConfiguracaoRepository.cs
@@ -1,0 +1,12 @@
+using Sistema.CORE.Entities;
+
+namespace Sistema.CORE.Interfaces;
+
+public interface IConfiguracaoRepository
+{
+    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento);
+    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave);
+    Task<Configuracao> AdicionarAsync(Configuracao config);
+    Task AtualizarAsync(Configuracao config);
+    Task RemoverAsync(int id);
+}

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
@@ -8,5 +8,6 @@ public interface IUnitOfWork
     IPerfilFuncionalidadeRepository PerfilFuncionalidades { get; }
     ILogRepository Logs { get; }
     ITemaRepository Temas { get; }
+    IConfiguracaoRepository Configuracoes { get; }
     Task<int> ConfirmarAsync();
 }

--- a/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
@@ -1,0 +1,39 @@
+using Sistema.CORE.Entities;
+using Sistema.CORE.Interfaces;
+
+namespace Sistema.CORE.Services;
+
+public class ConfiguracaoService : IConfiguracaoService
+{
+    private readonly IUnitOfWork _uow;
+
+    public ConfiguracaoService(IUnitOfWork uow)
+    {
+        _uow = uow;
+    }
+
+    public Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento) =>
+        _uow.Configuracoes.BuscarPorAgrupamentoAsync(agrupamento);
+
+    public Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave) =>
+        _uow.Configuracoes.BuscarPorChaveAsync(agrupamento, chave);
+
+    public async Task<Configuracao> AdicionarAsync(Configuracao config)
+    {
+        var result = await _uow.Configuracoes.AdicionarAsync(config);
+        await _uow.ConfirmarAsync();
+        return result;
+    }
+
+    public async Task AtualizarAsync(Configuracao config)
+    {
+        await _uow.Configuracoes.AtualizarAsync(config);
+        await _uow.ConfirmarAsync();
+    }
+
+    public async Task RemoverAsync(int id)
+    {
+        await _uow.Configuracoes.RemoverAsync(id);
+        await _uow.ConfirmarAsync();
+    }
+}

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
@@ -1,0 +1,12 @@
+using Sistema.CORE.Entities;
+
+namespace Sistema.CORE.Interfaces;
+
+public interface IConfiguracaoService
+{
+    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento);
+    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave);
+    Task<Configuracao> AdicionarAsync(Configuracao config);
+    Task AtualizarAsync(Configuracao config);
+    Task RemoverAsync(int id);
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext : DbContext
     public DbSet<Funcionalidade> Funcionalidades => Set<Funcionalidade>();
     public DbSet<PerfilFuncionalidade> PerfilFuncionalidades => Set<PerfilFuncionalidade>();
     public DbSet<Tema> Temas => Set<Tema>();
+    public DbSet<Configuracao> Configuracoes => Set<Configuracao>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/ConfiguracaoMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/ConfiguracaoMap.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class ConfiguracaoMap : IEntityTypeConfiguration<Configuracao>
+{
+    public void Configure(EntityTypeBuilder<Configuracao> builder)
+    {
+        builder.ToTable("Configuracao");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Agrupamento).IsRequired();
+        builder.Property(c => c.Chave).IsRequired();
+        builder.Property(c => c.Valor).IsRequired();
+        builder.Property(c => c.Tipo).IsRequired();
+        builder.Property(c => c.Ativo).HasDefaultValue(true);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/ConfiguracaoRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/ConfiguracaoRepository.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Sistema.CORE.Entities;
+using Sistema.CORE.Interfaces;
+using Sistema.INFRA.Data;
+
+namespace Sistema.INFRA.Repositories;
+
+public class ConfiguracaoRepository : IConfiguracaoRepository
+{
+    private readonly AppDbContext _context;
+
+    public ConfiguracaoRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento) =>
+        await _context.Configuracoes
+            .Where(c => c.Agrupamento == agrupamento && c.Ativo)
+            .ToListAsync();
+
+    public async Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave) =>
+        await _context.Configuracoes
+            .FirstOrDefaultAsync(c => c.Agrupamento == agrupamento && c.Chave == chave);
+
+    public Task<Configuracao> AdicionarAsync(Configuracao config)
+    {
+        _context.Configuracoes.Add(config);
+        return Task.FromResult(config);
+    }
+
+    public Task AtualizarAsync(Configuracao config)
+    {
+        _context.Configuracoes.Update(config);
+        return Task.CompletedTask;
+    }
+
+    public async Task RemoverAsync(int id)
+    {
+        var entity = await _context.Configuracoes.FindAsync(id);
+        if (entity != null)
+        {
+            _context.Configuracoes.Remove(entity);
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFuncionalidadeRepository, FuncionalidadeRepository>();
         services.AddScoped<IPerfilFuncionalidadeRepository, PerfilFuncionalidadeRepository>();
         services.AddScoped<ITemaRepository, TemaRepository>();
+        services.AddScoped<IConfiguracaoRepository, ConfiguracaoRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IEmailService, EmailService>();
  

--- a/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
@@ -12,6 +12,7 @@ public class UnitOfWork : IUnitOfWork
     public IFuncionalidadeRepository Funcionalidades { get; }
     public IPerfilFuncionalidadeRepository PerfilFuncionalidades { get; }
     public ITemaRepository Temas { get; }
+    public IConfiguracaoRepository Configuracoes { get; }
 
     public UnitOfWork(AppDbContext context,
                       IPerfilRepository perfis,
@@ -19,7 +20,8 @@ public class UnitOfWork : IUnitOfWork
                       ILogRepository logs,
                       IFuncionalidadeRepository funcionalidades,
                       IPerfilFuncionalidadeRepository perfilFuncs,
-                      ITemaRepository temas)
+                      ITemaRepository temas,
+                      IConfiguracaoRepository configuracoes)
     {
         _context = context;
         Perfis = perfis;
@@ -28,6 +30,7 @@ public class UnitOfWork : IUnitOfWork
         Funcionalidades = funcionalidades;
         PerfilFuncionalidades = perfilFuncs;
         Temas = temas;
+        Configuracoes = configuracoes;
     }
 
     public Task<int> ConfirmarAsync() => _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- add `Configuracao` entity and type enum for generic settings storage
- implement repository and service layer for managing settings
- wire up infrastructure, unit of work, and DI registrations

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689dfdbe5b60832c968dc1ea659b6fa1