### PR TITLE
Run migrations and seed data at startup

### DIFF
--- a/0 - Apresentacao/Sistema.API/Program.cs
+++ b/0 - Apresentacao/Sistema.API/Program.cs
@@ -54,7 +54,10 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     if (db.Database.IsRelational())
+    {
         db.Database.Migrate();
+        DbInitializer.Seed(db);
+    }
 }
 
 app.Run();

--- a/0 - Apresentacao/Sistema.MVC/Program.cs
+++ b/0 - Apresentacao/Sistema.MVC/Program.cs
@@ -34,7 +34,10 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     if (db.Database.IsRelational())
+    {
         db.Database.Migrate();
+        DbInitializer.Seed(db);
+    }
 }
 
 app.MapControllerRoute(

--- a/3 - Infraestrutura/Sistema.INFRA/Data/DbInitializer.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/DbInitializer.cs
@@ -7,8 +7,6 @@ public static class DbInitializer
 {
     public static void Seed(AppDbContext context)
     {
-        context.Database.EnsureCreated();
-
         if (!context.Perfis.Any())
         {
             context.Perfis.AddRange(AdminSeed.Get(), UserSeed.Get());


### PR DESCRIPTION
## Summary
- remove database creation from `DbInitializer`
- apply migrations and seed database on API and MVC startup

## Testing
- `dotnet build` *(fails: current SDK 8.0 does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68af75308258832c9bfc3c616ed38223