### PR TITLE
Fix seed data identity insert error

### DIFF
--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminSeed.cs
@@ -6,7 +6,6 @@ public static class AdminSeed
 {
     public static Perfil Get() => new()
     {
-        Id = 1,
         Nome = "Admin",
         UsuarioInclusao = "seed",
         Ativo = true

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminUserSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/AdminUserSeed.cs
@@ -10,7 +10,6 @@ public static class AdminUserSeed
     {
         var user = new Usuario
         {
-            Id = 1,
             Nome = "Rafael",
             Cpf = "00000000000",
             PerfilId = 1,

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/ComercialUserSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/ComercialUserSeed.cs
@@ -10,7 +10,6 @@ public static class ComercialUserSeed
     {
         var user = new Usuario
         {
-            Id = 2,
             Nome = "Allison",
             Cpf = "00000000001",
             PerfilId = 2,

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/FuncionalidadeSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/FuncionalidadeSeed.cs
@@ -8,9 +8,9 @@ public static class FuncionalidadeSeed
     {
         return new List<Funcionalidade>
         {
-            new() { Id = 1, Nome = "Perfil", UsuarioInclusao = "seed" },
-            new() { Id = 2, Nome = "Usuario", UsuarioInclusao = "seed" },
-            new() { Id = 3, Nome = "Log", UsuarioInclusao = "seed" }
+            new() { Nome = "Perfil", UsuarioInclusao = "seed" },
+            new() { Nome = "Usuario", UsuarioInclusao = "seed" },
+            new() { Nome = "Log", UsuarioInclusao = "seed" }
         };
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/UserSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/UserSeed.cs
@@ -6,9 +6,8 @@ public static class UserSeed
 {
     public static Perfil Get() => new()
     {
-        Id = 2,
-        Nome = "Comercial", 
+        Nome = "Comercial",
         UsuarioInclusao = "seed",
-        Ativo = true 
+        Ativo = true
     };
 }


### PR DESCRIPTION
## Summary
- remove explicit `Id` values from `Perfil` and `Usuario` seed classes so identity columns are filled automatically
- drop hard-coded IDs in `Funcionalidade` seed entries to rely on auto-incremented keys

## Testing
- `dotnet build` *(fails: .NET SDK 8.0 does not support target .NET 9.0)*
- `dotnet test` *(fails: .NET SDK 8.0 does not support target .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68af7d958384832c85761c13f8387f13