### PR TITLE
Improve sidebar behavior and theme panel layering

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -112,7 +112,7 @@
     <script src="https://cdn.jsdelivr.net/npm/izimodal/js/iziModal.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
-    <aside id="temaSidebar" class="tema-sidebar @rightText" style="background-color:@rightColor" data-aos="fade-left">
+    <aside id="temaSidebar" class="tema-sidebar @rightText" style="background-color:@rightColor">
         <form asp-controller="Tema" asp-action="Edit" method="post" class="p-3">
             <h5>Preferências de Tema</h5>
             <div class="mb-3">

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -36,7 +36,14 @@ body {
   text-align: start;
 }
 
- .tema-sidebar {
+
+header.navbar,
+footer.footer {
+  position: relative;
+  z-index: 1001;
+}
+
+.tema-sidebar {
    position: fixed;
    top: 0;
    right: 0;
@@ -44,7 +51,7 @@ body {
    width: 300px;
    transform: translateX(100%);
    transition: transform 0.3s ease;
-   z-index: 900;
+   z-index: 1000;
    overflow-y: auto;
  }
 
@@ -54,15 +61,15 @@ body {
 
  .sidebar {
    width: 200px;
-   flex: 0 0 200px;
-   transition: width 0.3s;
+   min-width: 60px;
+   flex-shrink: 0;
+   transition: width 0.3s ease;
    overflow-x: hidden;
    position: relative;
  }
 
  .sidebar.collapsed {
    width: 60px;
-   flex: 0 0 60px;
  }
 
  .sidebar.collapsed .nav-link span {
@@ -79,8 +86,10 @@ body {
 
  .sidebar.collapsed:hover {
    width: 200px;
-   flex: 0 0 200px;
    position: absolute;
+   top: 0;
+   bottom: 0;
+   left: 0;
    z-index: 1000;
  }
 


### PR DESCRIPTION
## Summary
- Ensure header and footer appear above the theme sidebar and remove conflicting animation attribute
- Refine sidebar collapse/expand behaviour with smoother transitions and full-height hover state

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2029e99c4832c9d720e4644218950