### PR TITLE
feat: add messaging system and user docs

### DIFF
--- a/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
@@ -1,0 +1,62 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using Sistema.APP.DTOs;
+using Sistema.CORE.Services.Interfaces;
+using System;
+
+namespace Sistema.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class MensagemController : ControllerBase
+    {
+        private readonly IMensagemService _mensagemService;
+        private readonly IMapper _mapper;
+
+        public MensagemController(IMensagemService mensagemService, IMapper mapper)
+        {
+            _mensagemService = mensagemService;
+            _mapper = mapper;
+        }
+
+        [HttpGet("entrada")]
+        public async Task<IActionResult> Entrada(int usuarioId, int page = 1, int pageSize = 20, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null)
+        {
+            var result = await _mensagemService.BuscarCaixaEntradaAsync(usuarioId, page, pageSize, remetenteId, palavraChave, inicio, fim);
+            var dto = result.Items.Select(m => _mapper.Map<MensagemDto>(m));
+            return Ok(new { result.TotalItems, result.Page, result.PageSize, Items = dto });
+        }
+
+        [HttpGet("saida")]
+        public async Task<IActionResult> Saida(int usuarioId, int page = 1, int pageSize = 20)
+        {
+            var result = await _mensagemService.BuscarCaixaSaidaAsync(usuarioId, page, pageSize);
+            var dto = result.Items.Select(m => _mapper.Map<MensagemDto>(m));
+            return Ok(new { result.TotalItems, result.Page, result.PageSize, Items = dto });
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(int id)
+        {
+            var msg = await _mensagemService.BuscarPorIdAsync(id);
+            if (msg == null) return NotFound();
+            return Ok(_mapper.Map<MensagemDto>(msg));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Post([FromBody] NovaMensagemDto dto)
+        {
+            var result = await _mensagemService.EnviarAsync(dto.RemetenteId, dto.DestinatarioId, dto.Assunto, dto.Corpo, dto.MensagemPaiId);
+            if (!result.Success) return BadRequest(result.Message);
+            return CreatedAtAction(nameof(Get), new { id = result.Data }, result.Data);
+        }
+
+        [HttpPost("{id}/ler")]
+        public async Task<IActionResult> MarcarComoLida(int id, int usuarioId)
+        {
+            var result = await _mensagemService.MarcarComoLidaAsync(id, usuarioId);
+            if (!result.Success) return BadRequest(result.Message);
+            return NoContent();
+        }
+    }
+}

--- a/0 - Apresentacao/Sistema.MVC/Controllers/DocumentacaoController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/DocumentacaoController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sistema.MVC.Controllers
+{
+    public class DocumentacaoController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/0 - Apresentacao/Sistema.MVC/Controllers/MensagemController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/MensagemController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Sistema.CORE.Services.Interfaces;
+using Sistema.MVC.Models;
+using AutoMapper;
+using System;
+
+namespace Sistema.MVC.Controllers
+{
+    public class MensagemController : Controller
+    {
+        private readonly IMensagemService _mensagemService;
+        private readonly IMapper _mapper;
+
+        public MensagemController(IMensagemService mensagemService, IMapper mapper)
+        {
+            _mensagemService = mensagemService;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(int page = 1, int pageSize = 20, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null)
+        {
+            var userId = HttpContext.Session.GetInt32("UserId");
+            if (userId is null) return RedirectToAction("Login", "Account");
+            var result = await _mensagemService.BuscarCaixaEntradaAsync(userId.Value, page, pageSize, remetenteId, palavraChave, inicio, fim);
+            var model = new MensagemViewModel
+            {
+                Mensagens = result.Items.Select(m => _mapper.Map<Sistema.APP.DTOs.MensagemDto>(m)).ToList(),
+                Page = result.Page,
+                PageSize = result.PageSize,
+                TotalItems = result.TotalItems,
+                RemetenteId = remetenteId,
+                PalavraChave = palavraChave,
+                Inicio = inicio,
+                Fim = fim
+            };
+            return View(model);
+        }
+
+        [HttpGet]
+        public IActionResult Nova(int? mensagemPaiId = null, int? destinatarioId = null)
+        {
+            ViewBag.MensagemPaiId = mensagemPaiId;
+            ViewBag.DestinatarioId = destinatarioId;
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Nova(int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null)
+        {
+            var remetenteId = HttpContext.Session.GetInt32("UserId");
+            if (remetenteId is null) return RedirectToAction("Login", "Account");
+            await _mensagemService.EnviarAsync(remetenteId, destinatarioId, assunto, corpo, mensagemPaiId);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Detalhe(int id)
+        {
+            var userId = HttpContext.Session.GetInt32("UserId");
+            if (userId is null) return RedirectToAction("Login", "Account");
+            var msg = await _mensagemService.BuscarPorIdAsync(id);
+            if (msg == null) return NotFound();
+            if (msg.DestinatarioId == userId) await _mensagemService.MarcarComoLidaAsync(id, userId.Value);
+            return View(_mapper.Map<Sistema.APP.DTOs.MensagemDto>(msg));
+        }
+    }
+}

--- a/0 - Apresentacao/Sistema.MVC/Models/MensagemViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/MensagemViewModel.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Sistema.APP.DTOs;
+
+namespace Sistema.MVC.Models
+{
+    public class MensagemViewModel
+    {
+        public List<MensagemDto> Mensagens { get; set; } = new();
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+        public int TotalItems { get; set; }
+        public int? RemetenteId { get; set; }
+        public string? PalavraChave { get; set; }
+        public DateTime? Inicio { get; set; }
+        public DateTime? Fim { get; set; }
+    }
+}

--- a/0 - Apresentacao/Sistema.MVC/Views/Documentacao/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Documentacao/Index.cshtml
@@ -1,0 +1,12 @@
+@{
+    ViewData["Title"] = "Documentação do Sistema";
+}
+<h2>Documentação do Sistema</h2>
+<p>Esta página descreve de forma simples como utilizar as principais telas do sistema.</p>
+<ul>
+    <li><strong>Login:</strong> informe CPF e senha para acessar. Há opções de registro e recuperação de senha.</li>
+    <li><strong>Página inicial:</strong> apresenta o painel geral após o login.</li>
+    <li><strong>Configurações:</strong> permite listar, criar e editar configurações diversas.</li>
+    <li><strong>Tema:</strong> personalize cores, modo escuro e disposição do layout.</li>
+    <li><strong>Mensagens:</strong> caixa de entrada para trocar mensagens entre usuários, com busca por palavras-chave e respostas encadeadas.</li>
+</ul>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
@@ -1,0 +1,13 @@
+@model Sistema.APP.DTOs.MensagemDto
+@{
+    ViewData["Title"] = Model.Assunto;
+}
+<h2>@Model.Assunto</h2>
+<div>
+    <strong>De:</strong> @Model.RemetenteNome<br />
+    <strong>Para:</strong> @Model.DestinatarioNome<br />
+    <strong>Data:</strong> @Model.DataInclusao.ToLocalTime().ToString("g")
+</div>
+<hr />
+<div>@Model.Corpo</div>
+<a href="@Url.Action("Nova", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })" class="btn btn-secondary mt-3">Responder</a>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
@@ -1,0 +1,31 @@
+@model Sistema.MVC.Models.MensagemViewModel
+@{
+    ViewData["Title"] = "Caixa de Entrada";
+}
+<h2>Mensagens</h2>
+<form method="get">
+    <input type="text" name="palavraChave" placeholder="Buscar" value="@Model.PalavraChave" />
+    <button type="submit">Buscar</button>
+</form>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Assunto</th>
+            <th>Remetente</th>
+            <th>Data</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var m in Model.Mensagens)
+    {
+        <tr class="@(m.Lida ? "" : "fw-bold")">
+            <td>@m.Assunto</td>
+            <td>@m.RemetenteNome</td>
+            <td>@m.DataInclusao.ToLocalTime().ToString("g")</td>
+            <td><a href="@Url.Action("Detalhe", new { id = m.Id })">Abrir</a></td>
+        </tr>
+    }
+    </tbody>
+</table>
+<a href="@Url.Action("Nova")" class="btn btn-primary">Nova mensagem</a>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
@@ -1,0 +1,22 @@
+@{
+    ViewData["Title"] = "Nova Mensagem";
+    var destinatarioId = ViewBag.DestinatarioId as int?;
+    var mensagemPaiId = ViewBag.MensagemPaiId as int?;
+}
+<h2>Nova mensagem</h2>
+<form method="post">
+    <input type="hidden" name="mensagemPaiId" value="@mensagemPaiId" />
+    <div class="mb-3">
+        <label>Destinatário</label>
+        <input type="number" name="destinatarioId" class="form-control" value="@destinatarioId" required />
+    </div>
+    <div class="mb-3">
+        <label>Assunto</label>
+        <input type="text" name="assunto" class="form-control" required />
+    </div>
+    <div class="mb-3">
+        <label>Corpo</label>
+        <textarea name="corpo" class="form-control" rows="5"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Enviar</button>
+</form>

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -91,6 +91,12 @@
                         <li class="nav-item">
                             <a class="nav-link @leftText" asp-controller="Configuracao" asp-action="Index"><i class="bi bi-gear me-2"></i><span>Configurações</span></a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link @leftText" asp-controller="Mensagem" asp-action="Index"><i class="bi bi-envelope me-2"></i><span>Mensagens</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link @leftText" asp-controller="Documentacao" asp-action="Index"><i class="bi bi-book me-2"></i><span>Documentação</span></a>
+                        </li>
                     </ul>
                 </nav>
             </aside>

--- a/1 - Aplicacao/Sistema.APP/DTOs/MensagemDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/MensagemDto.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Sistema.APP.DTOs
+{
+    public class MensagemDto
+    {
+        public int Id { get; set; }
+        public int? RemetenteId { get; set; }
+        public string RemetenteNome { get; set; } = string.Empty;
+        public int DestinatarioId { get; set; }
+        public string DestinatarioNome { get; set; } = string.Empty;
+        public string Assunto { get; set; } = string.Empty;
+        public string Corpo { get; set; } = string.Empty;
+        public bool Lida { get; set; }
+        public DateTime DataInclusao { get; set; }
+        public DateTime? DataLeitura { get; set; }
+        public int? MensagemPaiId { get; set; }
+    }
+}

--- a/1 - Aplicacao/Sistema.APP/DTOs/NovaMensagemDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/NovaMensagemDto.cs
@@ -1,0 +1,11 @@
+namespace Sistema.APP.DTOs
+{
+    public class NovaMensagemDto
+    {
+        public int? RemetenteId { get; set; }
+        public int DestinatarioId { get; set; }
+        public string Assunto { get; set; } = string.Empty;
+        public string Corpo { get; set; } = string.Empty;
+        public int? MensagemPaiId { get; set; }
+    }
+}

--- a/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
+++ b/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
@@ -14,6 +14,10 @@ public class MappingProfile : Profile
             .ForMember(d => d.SenhaHash, o => o.MapFrom(s => s.SenhaHash))
             .ForMember(d => d.Ativo, o => o.MapFrom(s => s.Ativo))
             .ReverseMap();
-		CreateMap<Configuracao, ConfiguracaoDto>().ReverseMap();
-	}
+        CreateMap<Configuracao, ConfiguracaoDto>().ReverseMap();
+        CreateMap<Mensagem, MensagemDto>()
+            .ForMember(d => d.RemetenteNome, o => o.MapFrom(s => s.Remetente != null ? s.Remetente.Nome : "Sistema"))
+            .ForMember(d => d.DestinatarioNome, o => o.MapFrom(s => s.Destinatario.Nome));
+        CreateMap<NovaMensagemDto, Mensagem>();
+    }
 }

--- a/1 - Aplicacao/Sistema.APP/ServiceCollectionExtensions.cs
+++ b/1 - Aplicacao/Sistema.APP/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped<ITemaService, TemaService>();
         services.AddScoped<IConfiguracaoService, ConfiguracaoService>();
+        services.AddScoped<IMensagemService, MensagemService>();
         services.AddScoped<IPasswordHasher<Usuario>, PasswordHasher<Usuario>>();
         services.AddAutoMapper(typeof(MappingProfile));
         return services;

--- a/2 - Dominio/Sistema.CORE/Entities/Mensagem.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Mensagem.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Sistema.CORE.Entities
+{
+    public class Mensagem : AuditableEntity
+    {
+        public int Id { get; set; }
+        public int? RemetenteId { get; set; }
+        public Usuario? Remetente { get; set; }
+        public int DestinatarioId { get; set; }
+        public Usuario Destinatario { get; set; } = null!;
+        public string Assunto { get; set; } = string.Empty;
+        public string Corpo { get; set; } = string.Empty;
+        public bool Lida { get; set; }
+        public DateTime? DataLeitura { get; set; }
+        public int? MensagemPaiId { get; set; }
+        public Mensagem? MensagemPai { get; set; }
+    }
+}

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
@@ -1,0 +1,14 @@
+using Sistema.CORE.Entities;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sistema.CORE.Interfaces
+{
+    public interface IMensagemRepository
+    {
+        Task<Mensagem?> GetByIdAsync(int id);
+        IQueryable<Mensagem> Query();
+        Task AddAsync(Mensagem mensagem);
+        void Update(Mensagem mensagem);
+    }
+}

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
@@ -9,5 +9,6 @@ public interface IUnitOfWork
     ILogRepository Logs { get; }
     ITemaRepository Temas { get; }
     IConfiguracaoRepository Configuracoes { get; }
+    IMensagemRepository Mensagens { get; }
     Task<int> ConfirmarAsync();
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
@@ -1,0 +1,16 @@
+using Sistema.CORE.Common;
+using Sistema.CORE.Entities;
+using System;
+using System.Threading.Tasks;
+
+namespace Sistema.CORE.Services.Interfaces
+{
+    public interface IMensagemService
+    {
+        Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null);
+        Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize);
+        Task<Mensagem?> BuscarPorIdAsync(int id);
+        Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null);
+        Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId);
+    }
+}

--- a/2 - Dominio/Sistema.CORE/Services/MensagemService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/MensagemService.cs
@@ -1,0 +1,83 @@
+using Sistema.CORE.Common;
+using Sistema.CORE.Entities;
+using Sistema.CORE.Interfaces;
+using Sistema.CORE.Services.Interfaces;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sistema.CORE.Services
+{
+    public class MensagemService : IMensagemService
+    {
+        private readonly IUnitOfWork _uow;
+
+        public MensagemService(IUnitOfWork uow)
+        {
+            _uow = uow;
+        }
+
+        public Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null)
+        {
+            var query = _uow.Mensagens.Query()
+                .Where(m => m.DestinatarioId == usuarioId)
+                .OrderByDescending(m => m.DataInclusao);
+
+            if (remetenteId.HasValue)
+                query = query.Where(m => m.RemetenteId == remetenteId.Value);
+            if (!string.IsNullOrWhiteSpace(palavraChave))
+                query = query.Where(m => m.Assunto.Contains(palavraChave) || m.Corpo.Contains(palavraChave));
+            if (inicio.HasValue)
+                query = query.Where(m => m.DataInclusao >= inicio.Value);
+            if (fim.HasValue)
+                query = query.Where(m => m.DataInclusao <= fim.Value);
+
+            var total = query.Count();
+            var items = query.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            return Task.FromResult(new PagedResult<Mensagem>(items, total, page, pageSize));
+        }
+
+        public Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize)
+        {
+            var query = _uow.Mensagens.Query()
+                .Where(m => m.RemetenteId == usuarioId)
+                .OrderByDescending(m => m.DataInclusao);
+            var total = query.Count();
+            var items = query.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            return Task.FromResult(new PagedResult<Mensagem>(items, total, page, pageSize));
+        }
+
+        public Task<Mensagem?> BuscarPorIdAsync(int id) => _uow.Mensagens.GetByIdAsync(id);
+
+        public async Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null)
+        {
+            var msg = new Mensagem
+            {
+                RemetenteId = remetenteId,
+                DestinatarioId = destinatarioId,
+                Assunto = assunto,
+                Corpo = corpo,
+                MensagemPaiId = mensagemPaiId,
+                Lida = false
+            };
+            await _uow.Mensagens.AddAsync(msg);
+            await _uow.ConfirmarAsync();
+            return OperationResult<int>.Success(msg.Id);
+        }
+
+        public async Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId)
+        {
+            var msg = await _uow.Mensagens.GetByIdAsync(id);
+            if (msg == null || msg.DestinatarioId != usuarioId)
+                return OperationResult.Failure("Mensagem não encontrada");
+            if (!msg.Lida)
+            {
+                msg.Lida = true;
+                msg.DataLeitura = DateTime.UtcNow;
+                _uow.Mensagens.Update(msg);
+                await _uow.ConfirmarAsync();
+            }
+            return OperationResult.Success();
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
@@ -18,6 +18,7 @@ public class AppDbContext : DbContext
     public DbSet<PerfilFuncionalidade> PerfilFuncionalidades => Set<PerfilFuncionalidade>();
     public DbSet<Tema> Temas => Set<Tema>();
     public DbSet<Configuracao> Configuracoes => Set<Configuracao>();
+    public DbSet<Mensagem> Mensagens => Set<Mensagem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping
+{
+    public class MensagemMap : IEntityTypeConfiguration<Mensagem>
+    {
+        public void Configure(EntityTypeBuilder<Mensagem> builder)
+        {
+            builder.ToTable("Mensagens");
+
+            builder.HasKey(m => m.Id);
+
+            builder.HasOne(m => m.Remetente)
+                .WithMany()
+                .HasForeignKey(m => m.RemetenteId)
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(m => m.Destinatario)
+                .WithMany()
+                .HasForeignKey(m => m.DestinatarioId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(m => m.MensagemPai)
+                .WithMany()
+                .HasForeignKey(m => m.MensagemPaiId)
+                .IsRequired(false);
+
+            builder.Property(m => m.Assunto).HasMaxLength(200);
+            builder.Property(m => m.Corpo).IsRequired();
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901000000_AddMensagem.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901000000_AddMensagem.cs
@@ -1,0 +1,70 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sistema.INFRA.Migrations
+{
+    public partial class AddMensagem : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Mensagens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RemetenteId = table.Column<int>(type: "int", nullable: true),
+                    DestinatarioId = table.Column<int>(type: "int", nullable: false),
+                    Assunto = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Corpo = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Lida = table.Column<bool>(type: "bit", nullable: false),
+                    DataLeitura = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    MensagemPaiId = table.Column<int>(type: "int", nullable: true),
+                    DataInclusao = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DataAlteracao = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UsuarioInclusao = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    UsuarioAlteracao = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Mensagens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Usuario_DestinatarioId",
+                        column: x => x.DestinatarioId,
+                        principalTable: "Usuario",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Usuario_RemetenteId",
+                        column: x => x.RemetenteId,
+                        principalTable: "Usuario",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Mensagens_MensagemPaiId",
+                        column: x => x.MensagemPaiId,
+                        principalTable: "Mensagens",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_DestinatarioId",
+                table: "Mensagens",
+                column: "DestinatarioId");
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_RemetenteId",
+                table: "Mensagens",
+                column: "RemetenteId");
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_MensagemPaiId",
+                table: "Mensagens",
+                column: "MensagemPaiId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Mensagens");
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Sistema.CORE.Entities;
+using Sistema.CORE.Repositories.Interfaces;
+using Sistema.INFRA.Data;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sistema.INFRA.Repositories
+{
+    public class MensagemRepository : IMensagemRepository
+    {
+        private readonly AppDbContext _context;
+
+        public MensagemRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddAsync(Mensagem mensagem)
+        {
+            await _context.Mensagens.AddAsync(mensagem);
+        }
+
+        public async Task<Mensagem?> GetByIdAsync(int id)
+        {
+            return await _context.Mensagens
+                .Include(m => m.Remetente)
+                .Include(m => m.Destinatario)
+                .Include(m => m.MensagemPai)
+                .FirstOrDefaultAsync(m => m.Id == id);
+        }
+
+        public IQueryable<Mensagem> Query()
+        {
+            return _context.Mensagens.AsQueryable();
+        }
+
+        public void Update(Mensagem mensagem)
+        {
+            _context.Mensagens.Update(mensagem);
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPerfilFuncionalidadeRepository, PerfilFuncionalidadeRepository>();
         services.AddScoped<ITemaRepository, TemaRepository>();
         services.AddScoped<IConfiguracaoRepository, ConfiguracaoRepository>();
+        services.AddScoped<IMensagemRepository, MensagemRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IEmailService, EmailService>();
  

--- a/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
@@ -13,6 +13,7 @@ public class UnitOfWork : IUnitOfWork
     public IPerfilFuncionalidadeRepository PerfilFuncionalidades { get; }
     public ITemaRepository Temas { get; }
     public IConfiguracaoRepository Configuracoes { get; }
+    public IMensagemRepository Mensagens { get; }
 
     public UnitOfWork(AppDbContext context,
                       IPerfilRepository perfis,
@@ -21,7 +22,8 @@ public class UnitOfWork : IUnitOfWork
                       IFuncionalidadeRepository funcionalidades,
                       IPerfilFuncionalidadeRepository perfilFuncs,
                       ITemaRepository temas,
-                      IConfiguracaoRepository configuracoes)
+                      IConfiguracaoRepository configuracoes,
+                      IMensagemRepository mensagens)
     {
         _context = context;
         Perfis = perfis;
@@ -31,6 +33,7 @@ public class UnitOfWork : IUnitOfWork
         PerfilFuncionalidades = perfilFuncs;
         Temas = temas;
         Configuracoes = configuracoes;
+        Mensagens = mensagens;
     }
 
     public Task<int> ConfirmarAsync() => _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- implement messaging domain, repository, service and API with search and threading
- add MVC inbox, reply, and message views
- document system screens for end users

## Testing
- `dotnet build Sistema.sln -c Release` *(fails: .NET 9 not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b77a6fc832cadc4e4c0550fd0fa