### PR TITLE
Use async repository operations with cancellation support

### DIFF
--- a/2 - Dominio/Sistema.CORE/Common/PagedResult.cs
+++ b/2 - Dominio/Sistema.CORE/Common/PagedResult.cs
@@ -1,15 +1,16 @@
 namespace Sistema.CORE.Common;
 
 using Microsoft.EntityFrameworkCore;
+using System.Threading;
 
 public record PagedResult<T>(IEnumerable<T> Items, int TotalCount, int Page, int PageSize);
 
 public static class IQueryableExtensions
 {
-    public static async Task<PagedResult<T>> ToPagedResultAsync<T>(this IQueryable<T> query, int page, int pageSize)
+    public static async Task<PagedResult<T>> ToPagedResultAsync<T>(this IQueryable<T> query, int page, int pageSize, CancellationToken cancellationToken = default)
     {
-        var count = await query.CountAsync();
-        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        var count = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
         return new PagedResult<T>(items, count, page, pageSize);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IConfiguracaoRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IConfiguracaoRepository.cs
@@ -1,12 +1,13 @@
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IConfiguracaoRepository
 {
-    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento);
-    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave);
-    Task<Configuracao> AdicionarAsync(Configuracao config);
+    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default);
+    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default);
+    Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Configuracao config);
-    Task RemoverAsync(int id);
+    Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IFuncionalidadeRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IFuncionalidadeRepository.cs
@@ -1,13 +1,14 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IFuncionalidadeRepository
 {
-    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize);
-    Task<Funcionalidade?> BuscarPorIdAsync(int id);
-    Task<Funcionalidade> AdicionarAsync(Funcionalidade func);
+    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Funcionalidade> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Funcionalidade func);
-    Task RemoverAsync(int id);
+    Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ILogRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ILogRepository.cs
@@ -1,9 +1,10 @@
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface ILogRepository
 {
-    Task AdicionarAsync(Log log);
-    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo);
+    Task AdicionarAsync(Log log, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
@@ -1,14 +1,15 @@
 using Sistema.CORE.Entities;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sistema.CORE.Interfaces
 {
     public interface IMensagemRepository
     {
-        Task<Mensagem?> GetByIdAsync(int id);
+        Task<Mensagem?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
         IQueryable<Mensagem> Query();
-        Task AddAsync(Mensagem mensagem);
+        Task AddAsync(Mensagem mensagem, CancellationToken cancellationToken = default);
         void Update(Mensagem mensagem);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IPerfilFuncionalidadeRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IPerfilFuncionalidadeRepository.cs
@@ -1,9 +1,10 @@
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IPerfilFuncionalidadeRepository
 {
-    Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId);
-    Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs);
+    Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId, CancellationToken cancellationToken = default);
+    Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IPerfilRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IPerfilRepository.cs
@@ -1,15 +1,16 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IPerfilRepository
 {
-    Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize);
-    Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize);
-    Task<Perfil?> BuscarPorIdAsync(int id);
-    Task<Perfil?> BuscarPorNomeAsync(string nome);
-    Task<Perfil> AdicionarAsync(Perfil perfil);
+    Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Perfil?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Perfil?> BuscarPorNomeAsync(string nome, CancellationToken cancellationToken = default);
+    Task<Perfil> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Perfil perfil);
-    Task RemoverAsync(int id);
+    Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ITemaRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ITemaRepository.cs
@@ -1,11 +1,12 @@
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface ITemaRepository
 {
-    Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId);
-    Task<Tema> AdicionarAsync(Tema tema);
+    Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId, CancellationToken cancellationToken = default);
+    Task<Tema> AdicionarAsync(Tema tema, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Tema tema);
 }
 

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUnitOfWork.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Sistema.CORE.Interfaces;
 
 public interface IUnitOfWork
@@ -10,5 +12,5 @@ public interface IUnitOfWork
     ITemaRepository Temas { get; }
     IConfiguracaoRepository Configuracoes { get; }
     IMensagemRepository Mensagens { get; }
-    Task<int> ConfirmarAsync();
+    Task<int> ConfirmarAsync(CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
@@ -1,16 +1,17 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IUsuarioRepository
 {
-    Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize);
-    Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize);
-    Task<Usuario?> BuscarPorIdAsync(int id);
-    Task<Usuario?> BuscarPorCpfAsync(string cpf);
-    Task<bool> ExisteAtivoPorPerfilAsync(int perfilId);
-    Task<Usuario> AdicionarAsync(Usuario usuario);
+    Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default);
+    Task<bool> ExisteAtivoPorPerfilAsync(int perfilId, CancellationToken cancellationToken = default);
+    Task<Usuario> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Usuario usuario);
-    Task RemoverAsync(int id);
+    Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/ConfiguracaoRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/ConfiguracaoRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -14,19 +15,19 @@ public class ConfiguracaoRepository : IConfiguracaoRepository
         _context = context;
     }
 
-    public async Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento) =>
+    public async Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default) =>
         await _context.Configuracoes
             .Where(c => c.Agrupamento == agrupamento && c.Ativo)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
-    public async Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave) =>
+    public async Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default) =>
         await _context.Configuracoes
-            .FirstOrDefaultAsync(c => c.Agrupamento == agrupamento && c.Chave == chave);
+            .FirstOrDefaultAsync(c => c.Agrupamento == agrupamento && c.Chave == chave, cancellationToken);
 
-    public Task<Configuracao> AdicionarAsync(Configuracao config)
+    public async Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default)
     {
-        _context.Configuracoes.Add(config);
-        return Task.FromResult(config);
+        await _context.Configuracoes.AddAsync(config, cancellationToken);
+        return config;
     }
 
     public Task AtualizarAsync(Configuracao config)
@@ -35,9 +36,9 @@ public class ConfiguracaoRepository : IConfiguracaoRepository
         return Task.CompletedTask;
     }
 
-    public async Task RemoverAsync(int id)
+    public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        var entity = await _context.Configuracoes.FindAsync(id);
+        var entity = await _context.Configuracoes.FindAsync(new object?[] { id }, cancellationToken);
         if (entity != null)
         {
             _context.Configuracoes.Remove(entity);

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/FuncionalidadeRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/FuncionalidadeRepository.cs
@@ -3,6 +3,7 @@ using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.INFRA.Data;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -15,22 +16,22 @@ public class FuncionalidadeRepository : IFuncionalidadeRepository
         _context = context;
     }
 
-    public Task<Funcionalidade> AdicionarAsync(Funcionalidade func)
+    public async Task<Funcionalidade> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
-        _context.Funcionalidades.Add(func);
-        return Task.FromResult(func);
+        await _context.Funcionalidades.AddAsync(func, cancellationToken);
+        return func;
     }
 
-    public async Task RemoverAsync(int id)
+    public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        var obj = await _context.Funcionalidades.FindAsync(id);
+        var obj = await _context.Funcionalidades.FindAsync(new object?[] { id }, cancellationToken);
         if (obj is null) return;
         _context.Funcionalidades.Remove(obj);
     }
 
-    public async Task<Funcionalidade?> BuscarPorIdAsync(int id)
+    public async Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default)
     {
-        return await _context.Funcionalidades.FindAsync(id);
+        return await _context.Funcionalidades.FindAsync(new object?[] { id }, cancellationToken);
     }
 
     public Task AtualizarAsync(Funcionalidade func)
@@ -39,9 +40,9 @@ public class FuncionalidadeRepository : IFuncionalidadeRepository
         return Task.CompletedTask;
     }
 
-    public async Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize)
+    public async Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _context.Funcionalidades.AsNoTracking().OrderBy(f => f.Id);
-        return await query.ToPagedResultAsync(page, pageSize);
+        return await query.ToPagedResultAsync(page, pageSize, cancellationToken);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
@@ -1,8 +1,9 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
-using Sistema.INFRA.Data; 
+using Sistema.INFRA.Data;
 using Microsoft.EntityFrameworkCore;
-using System.Linq; 
+using System.Linq;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -15,13 +16,12 @@ public class LogRepository : ILogRepository
         _context = context;
     }
 
-    public Task AdicionarAsync(Log log)
+    public async Task AdicionarAsync(Log log, CancellationToken cancellationToken = default)
     {
-        _context.Logs.Add(log);
-        return Task.CompletedTask;
-    } 
+        await _context.Logs.AddAsync(log, cancellationToken);
+    }
 
-    public async Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo)
+    public async Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
     {
         var query = _context.Logs.AsQueryable();
         if (inicio.HasValue)
@@ -30,6 +30,6 @@ public class LogRepository : ILogRepository
             query = query.Where(l => l.DataOperacao <= fim.Value);
         if (tipo.HasValue)
             query = query.Where(l => l.Tipo == tipo.Value);
-        return await query.AsNoTracking().ToListAsync();
-    } 
+        return await query.AsNoTracking().ToListAsync(cancellationToken);
+    }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
@@ -1,8 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
-using Sistema.CORE.Repositories.Interfaces;
+using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sistema.INFRA.Repositories
@@ -16,18 +17,18 @@ namespace Sistema.INFRA.Repositories
             _context = context;
         }
 
-        public async Task AddAsync(Mensagem mensagem)
+        public async Task AddAsync(Mensagem mensagem, CancellationToken cancellationToken = default)
         {
-            await _context.Mensagens.AddAsync(mensagem);
+            await _context.Mensagens.AddAsync(mensagem, cancellationToken);
         }
 
-        public async Task<Mensagem?> GetByIdAsync(int id)
+        public async Task<Mensagem?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             return await _context.Mensagens
                 .Include(m => m.Remetente)
                 .Include(m => m.Destinatario)
                 .Include(m => m.MensagemPai)
-                .FirstOrDefaultAsync(m => m.Id == id);
+                .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
         }
 
         public IQueryable<Mensagem> Query()

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilFuncionalidadeRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilFuncionalidadeRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -14,19 +15,19 @@ public class PerfilFuncionalidadeRepository : IPerfilFuncionalidadeRepository
         _context = context;
     }
 
-    public async Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId)
+    public async Task<IEnumerable<PerfilFuncionalidade>> BuscarPorPerfilIdAsync(int perfilId, CancellationToken cancellationToken = default)
     {
         return await _context.PerfilFuncionalidades
             .Include(pf => pf.Funcionalidade)
             .Where(pf => pf.PerfilId == perfilId)
             .AsNoTracking()
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 
-    public async Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs)
+    public async Task DefinirParaPerfilAsync(int perfilId, IEnumerable<PerfilFuncionalidade> funcs, CancellationToken cancellationToken = default)
     {
         var existing = _context.PerfilFuncionalidades.Where(pf => pf.PerfilId == perfilId);
         _context.PerfilFuncionalidades.RemoveRange(existing);
-        await _context.PerfilFuncionalidades.AddRangeAsync(funcs);
+        await _context.PerfilFuncionalidades.AddRangeAsync(funcs, cancellationToken);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/PerfilRepository.cs
@@ -1,9 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
-using Sistema.CORE.Interfaces; 
+using Sistema.CORE.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.INFRA.Data;
-using System.Linq; 
+using System.Linq;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -16,26 +17,26 @@ public class PerfilRepository : IPerfilRepository
         _context = context;
     }
 
-    public Task<Perfil> AdicionarAsync(Perfil perfil)
+    public async Task<Perfil> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default)
     {
-        _context.Perfis.Add(perfil);
-        return Task.FromResult(perfil);
+        await _context.Perfis.AddAsync(perfil, cancellationToken);
+        return perfil;
     }
 
-    public async Task RemoverAsync(int id)
+    public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        var perfil = await _context.Perfis.FindAsync(id);
+        var perfil = await _context.Perfis.FindAsync(new object?[] { id }, cancellationToken);
         if (perfil is null) return;
         _context.Perfis.Remove(perfil);
     }
- 
-    public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize)
+
+    public async Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _context.Perfis.AsNoTracking().OrderBy(p => p.Id);
-        return query.ToPagedResultAsync(page, pageSize);
+        return await query.ToPagedResultAsync(page, pageSize, cancellationToken);
     }
 
-    public Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize)
+    public async Task<PagedResult<Perfil>> BuscarFiltradosAsync(bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _context.Perfis.AsQueryable();
         if (ativo.HasValue)
@@ -43,17 +44,17 @@ public class PerfilRepository : IPerfilRepository
             query = query.Where(p => p.Ativo == ativo.Value);
         }
         query = query.AsNoTracking().OrderBy(p => p.Id);
-        return query.ToPagedResultAsync(page, pageSize); 
+        return await query.ToPagedResultAsync(page, pageSize, cancellationToken);
     }
 
-    public async Task<Perfil?> BuscarPorNomeAsync(string nome)
+    public async Task<Perfil?> BuscarPorNomeAsync(string nome, CancellationToken cancellationToken = default)
     {
-        return await _context.Perfis.FirstOrDefaultAsync(p => p.Nome == nome);
-    } 
-    
-    public async Task<Perfil?> BuscarPorIdAsync(int id)
+        return await _context.Perfis.FirstOrDefaultAsync(p => p.Nome == nome, cancellationToken);
+    }
+
+    public async Task<Perfil?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default)
     {
-        return await _context.Perfis.FindAsync(id);
+        return await _context.Perfis.FindAsync(new object?[] { id }, cancellationToken);
     }
 
     public Task AtualizarAsync(Perfil perfil)

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/TemaRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/TemaRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -14,13 +15,13 @@ public class TemaRepository : ITemaRepository
         _context = context;
     }
 
-    public async Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId) =>
-        await _context.Temas.FirstOrDefaultAsync(l => l.UsuarioId == usuarioId);
+    public async Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId, CancellationToken cancellationToken = default) =>
+        await _context.Temas.FirstOrDefaultAsync(l => l.UsuarioId == usuarioId, cancellationToken);
 
-    public Task<Tema> AdicionarAsync(Tema tema)
+    public async Task<Tema> AdicionarAsync(Tema tema, CancellationToken cancellationToken = default)
     {
-        _context.Temas.Add(tema);
-        return Task.FromResult(tema);
+        await _context.Temas.AddAsync(tema, cancellationToken);
+        return tema;
     }
 
     public Task AtualizarAsync(Tema tema)

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
@@ -1,9 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
-using Sistema.CORE.Interfaces; 
+using Sistema.CORE.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.INFRA.Data;
-using System.Linq; 
+using System.Linq;
+using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
 
@@ -16,26 +17,26 @@ public class UsuarioRepository : IUsuarioRepository
         _context = context;
     }
 
-    public Task<Usuario> AdicionarAsync(Usuario usuario)
+    public async Task<Usuario> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
-        _context.Usuarios.Add(usuario);
-        return Task.FromResult(usuario);
+        await _context.Usuarios.AddAsync(usuario, cancellationToken);
+        return usuario;
     }
 
-    public async Task RemoverAsync(int id)
+    public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        var usuario = await _context.Usuarios.FindAsync(id);
+        var usuario = await _context.Usuarios.FindAsync(new object?[] { id }, cancellationToken);
         if (usuario is null) return;
         _context.Usuarios.Remove(usuario);
     }
- 
-    public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize)
+
+    public async Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _context.Usuarios.AsNoTracking().OrderBy(u => u.Id);
-        return query.ToPagedResultAsync(page, pageSize);
+        return await query.ToPagedResultAsync(page, pageSize, cancellationToken);
     }
 
-    public Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize)
+    public async Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _context.Usuarios.AsQueryable();
         if (inicio.HasValue)
@@ -47,22 +48,22 @@ public class UsuarioRepository : IUsuarioRepository
         if (ativo.HasValue)
             query = query.Where(u => u.Ativo == ativo.Value);
         query = query.AsNoTracking().OrderBy(u => u.Id);
-        return query.ToPagedResultAsync(page, pageSize);
+        return await query.ToPagedResultAsync(page, pageSize, cancellationToken);
     }
 
-    public async Task<bool> ExisteAtivoPorPerfilAsync(int perfilId)
+    public async Task<bool> ExisteAtivoPorPerfilAsync(int perfilId, CancellationToken cancellationToken = default)
     {
-        return await _context.Usuarios.AnyAsync(u => u.PerfilId == perfilId && u.Ativo);
+        return await _context.Usuarios.AnyAsync(u => u.PerfilId == perfilId && u.Ativo, cancellationToken);
     }
 
-    public async Task<Usuario?> BuscarPorCpfAsync(string cpf)
+    public async Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default)
     {
-        return await _context.Usuarios.FirstOrDefaultAsync(u => u.Cpf == cpf);
+        return await _context.Usuarios.FirstOrDefaultAsync(u => u.Cpf == cpf, cancellationToken);
     }
 
-    public async Task<Usuario?> BuscarPorIdAsync(int id)
+    public async Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default)
     {
-        return await _context.Usuarios.FindAsync(id);
+        return await _context.Usuarios.FindAsync(new object?[] { id }, cancellationToken);
     }
 
     public Task AtualizarAsync(Usuario usuario)

--- a/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/UnitOfWork.cs
@@ -1,5 +1,6 @@
 using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
+using System.Threading;
 
 namespace Sistema.INFRA;
 
@@ -36,5 +37,5 @@ public class UnitOfWork : IUnitOfWork
         Mensagens = mensagens;
     }
 
-    public Task<int> ConfirmarAsync() => _context.SaveChangesAsync();
+    public Task<int> ConfirmarAsync(CancellationToken cancellationToken = default) => _context.SaveChangesAsync(cancellationToken);
 }


### PR DESCRIPTION
## Summary
- switch repository methods to use AddAsync and SaveChangesAsync equivalents
- add optional CancellationToken parameters across repository interfaces and implementations
- propagate tokens through paging helper

## Testing
- `dotnet build` *(fails: 'OperationResult' missing members in MensagemService)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bd7e120c832c95ad276bd13b2d5e