### PR TITLE
feat(api): add exception handling middleware

### DIFF
--- a/0 - Apresentacao/Sistema.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/0 - Apresentacao/Sistema.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sistema.API.Middleware;
+
+public class ExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+    public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private static Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        var problem = new ProblemDetails
+        {
+            Title = "Ocorreu um erro ao processar a requisição.",
+            Status = StatusCodes.Status500InternalServerError,
+            Detail = exception.Message,
+            Instance = context.Request.Path
+        };
+
+        context.Response.ContentType = "application/json";
+        context.Response.StatusCode = problem.Status ?? StatusCodes.Status500InternalServerError;
+        return context.Response.WriteAsJsonAsync(problem);
+    }
+}

--- a/0 - Apresentacao/Sistema.API/Program.cs
+++ b/0 - Apresentacao/Sistema.API/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Serilog;
+using Sistema.API.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -44,6 +45,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- add middleware to log unhandled exceptions and return ProblemDetails
- register middleware in the API pipeline

## Testing
- `dotnet build` *(fails: Cannot implicitly convert type 'IQueryable<Mensagem>' to 'IOrderedQueryable<Mensagem>' and other errors in MensagemService.cs)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bdbe294c832cb10a7d6b575d593e