### PR TITLE
feat: configurar envio de email via options

### DIFF
--- a/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/ServiceCollectionExtensions.cs
@@ -24,7 +24,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMensagemRepository, MensagemRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IEmailService, EmailService>();
- 
+        services.Configure<EmailOptions>(configuration.GetSection("AzureAd"));
+
         return services;
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Services/EmailOptions.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Services/EmailOptions.cs
@@ -1,0 +1,10 @@
+namespace Sistema.INFRA.Services;
+
+public class EmailOptions
+{
+    public string TenantId { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+    public string SenderEmail { get; set; } = string.Empty;
+}
+

--- a/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
@@ -1,5 +1,6 @@
 using Azure.Identity;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Users.Item.SendMail;
@@ -9,49 +10,59 @@ namespace Sistema.INFRA.Services;
 
 public class EmailService : IEmailService
 {
-    private readonly IConfiguration _config;
+    private readonly EmailOptions _options;
+    private readonly ILogger<EmailService> _logger;
 
-    public EmailService(IConfiguration config)
+    public EmailService(IOptions<EmailOptions> options, ILogger<EmailService> logger)
     {
-        _config = config;
+        _options = options.Value;
+        _logger = logger;
     }
 
     public async Task EnviarAsync(string destinatario, string assunto, string mensagem)
     {
-		var tenantId = _config["AzureAd:TenantId"];
-		var clientId = _config["AzureAd:ClientId"];
-		var clientSecret = _config["AzureAd:ClientSecret"];
-		var sender = _config["AzureAd:SenderEmail"];
+        var tenantId = _options.TenantId;
+        var clientId = _options.ClientId;
+        var clientSecret = _options.ClientSecret;
+        var sender = _options.SenderEmail;
 
-		var scopes = new[] { "https://graph.microsoft.com/.default" };
-		var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
-		var graphClient = new GraphServiceClient(credential, scopes);
+        var scopes = new[] { "https://graph.microsoft.com/.default" };
+        var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+        var graphClient = new GraphServiceClient(credential, scopes);
 
-		var message = new Message
-		{
-			Subject = assunto,
-			Body = new ItemBody
-			{
-				ContentType = BodyType.Html,
-				Content = mensagem
-			},
-			ToRecipients = new List<Recipient>
-			{
-				new Recipient
-				{
-					EmailAddress = new EmailAddress
-					{
-						Address = destinatario
-					}
-				}
-			}
-		};
-		var request = new SendMailPostRequestBody
-		{
-			Message = message,
-			SaveToSentItems = false
-		};
+        var message = new Message
+        {
+            Subject = assunto,
+            Body = new ItemBody
+            {
+                ContentType = BodyType.Html,
+                Content = mensagem
+            },
+            ToRecipients = new List<Recipient>
+            {
+                new Recipient
+                {
+                    EmailAddress = new EmailAddress
+                    {
+                        Address = destinatario
+                    }
+                }
+            }
+        };
+        var request = new SendMailPostRequestBody
+        {
+            Message = message,
+            SaveToSentItems = false
+        };
 
-		await graphClient.Users[sender].SendMail.PostAsync(request);
-	}
+        try
+        {
+            await graphClient.Users[sender].SendMail.PostAsync(request);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao enviar e-mail");
+            throw;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `EmailOptions` with Azure AD credentials
- inject options and logging into `EmailService`
- register email configuration in infrastructure services

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bde32898832cb71e59240b9d1039