### PR TITLE
Add max length constraints and unique indexes

### DIFF
--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContextFactory.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContextFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Sistema.INFRA.Data;
+
+public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseSqlServer("Data Source=localhost; Initial Catalog=SISTEMA; Trusted_Connection=True; TrustServerCertificate=True;");
+        return new AppDbContext(optionsBuilder.Options);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/ConfiguracaoMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/ConfiguracaoMap.cs
@@ -10,10 +10,11 @@ public class ConfiguracaoMap : IEntityTypeConfiguration<Configuracao>
     {
         builder.ToTable("Configuracao");
         builder.HasKey(c => c.Id);
-        builder.Property(c => c.Agrupamento).IsRequired();
-        builder.Property(c => c.Chave).IsRequired();
-        builder.Property(c => c.Valor).IsRequired();
+        builder.Property(c => c.Agrupamento).IsRequired().HasMaxLength(100);
+        builder.Property(c => c.Chave).IsRequired().HasMaxLength(100);
+        builder.Property(c => c.Valor).IsRequired().HasMaxLength(500);
         builder.Property(c => c.Tipo).IsRequired();
+        builder.Property(c => c.Descricao).HasMaxLength(500);
         builder.Property(c => c.Ativo).HasDefaultValue(true);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/FuncionalidadeMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/FuncionalidadeMap.cs
@@ -10,7 +10,7 @@ public class FuncionalidadeMap : IEntityTypeConfiguration<Funcionalidade>
     {
         builder.ToTable("Funcionalidade");
         builder.HasKey(f => f.Id);
-        builder.Property(f => f.Nome).IsRequired();
+        builder.Property(f => f.Nome).IsRequired().HasMaxLength(100);
         builder.Property(f => f.Ativo).HasDefaultValue(true);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
@@ -10,9 +10,9 @@ public class LogMap : IEntityTypeConfiguration<Log>
     {
         builder.ToTable("Log");
         builder.HasKey(l => l.Id);
-        builder.Property(l => l.Entidade).IsRequired();
-        builder.Property(l => l.Operacao).IsRequired();
-        builder.Property(l => l.Mensagem).IsRequired();
-        builder.Property(l => l.Usuario).IsRequired();
+        builder.Property(l => l.Entidade).IsRequired().HasMaxLength(100);
+        builder.Property(l => l.Operacao).IsRequired().HasMaxLength(100);
+        builder.Property(l => l.Mensagem).IsRequired().HasMaxLength(2000);
+        builder.Property(l => l.Usuario).IsRequired().HasMaxLength(100);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
@@ -29,7 +29,7 @@ namespace Sistema.INFRA.Mapping
                 .IsRequired(false);
 
             builder.Property(m => m.Assunto).HasMaxLength(200);
-            builder.Property(m => m.Corpo).IsRequired();
+            builder.Property(m => m.Corpo).IsRequired().HasMaxLength(2000);
         }
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/PerfilMap.cs
@@ -10,7 +10,9 @@ public class PerfilMap : IEntityTypeConfiguration<Perfil>
     {
         builder.ToTable("Perfil");
         builder.HasKey(p => p.Id);
-        builder.Property(p => p.Nome).IsRequired();
+        builder.Property(p => p.Nome).IsRequired().HasMaxLength(100);
         builder.Property(p => p.Ativo).HasDefaultValue(true);
+
+        builder.HasIndex(p => p.Nome).IsUnique();
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
@@ -10,10 +10,12 @@ public class UsuarioMap : IEntityTypeConfiguration<Usuario>
     {
         builder.ToTable("Usuario");
         builder.HasKey(u => u.Id);
-        builder.Property(u => u.Nome).IsRequired();
-        builder.Property(u => u.Cpf).IsRequired();
-        builder.Property(u => u.SenhaHash).IsRequired();
+        builder.Property(u => u.Nome).IsRequired().HasMaxLength(100);
+        builder.Property(u => u.Cpf).IsRequired().HasMaxLength(11);
+        builder.Property(u => u.SenhaHash).IsRequired().HasMaxLength(255);
         builder.Property(u => u.Ativo).HasDefaultValue(true);
+
+        builder.HasIndex(u => u.Cpf).IsUnique();
 
         builder.HasOne(u => u.Perfil)
                .WithMany()

--- a/3 - Infraestrutura/Sistema.INFRA/Migrations/20250831213311_AddStringConstraintsAndIndexes.Designer.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Migrations/20250831213311_AddStringConstraintsAndIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sistema.INFRA.Data;
 
@@ -11,9 +12,11 @@ using Sistema.INFRA.Data;
 namespace Sistema.INFRA.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250831213311_AddStringConstraintsAndIndexes")]
+    partial class AddStringConstraintsAndIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/3 - Infraestrutura/Sistema.INFRA/Migrations/20250831213311_AddStringConstraintsAndIndexes.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Migrations/20250831213311_AddStringConstraintsAndIndexes.cs
@@ -1,0 +1,333 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sistema.INFRA.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStringConstraintsAndIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SenhaHash",
+                table: "Usuario",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Usuario",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Cpf",
+                table: "Usuario",
+                type: "nvarchar(11)",
+                maxLength: 11,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Perfil",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Usuario",
+                table: "Log",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Operacao",
+                table: "Log",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mensagem",
+                table: "Log",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Entidade",
+                table: "Log",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Funcionalidade",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Valor",
+                table: "Configuracao",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Descricao",
+                table: "Configuracao",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Chave",
+                table: "Configuracao",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Agrupamento",
+                table: "Configuracao",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateTable(
+                name: "Mensagens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    RemetenteId = table.Column<int>(type: "int", nullable: true),
+                    DestinatarioId = table.Column<int>(type: "int", nullable: false),
+                    Assunto = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Corpo = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    Lida = table.Column<bool>(type: "bit", nullable: false),
+                    DataLeitura = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    MensagemPaiId = table.Column<int>(type: "int", nullable: true),
+                    DataInclusao = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DataAlteracao = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UsuarioInclusao = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    UsuarioAlteracao = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Mensagens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Mensagens_MensagemPaiId",
+                        column: x => x.MensagemPaiId,
+                        principalTable: "Mensagens",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Usuario_DestinatarioId",
+                        column: x => x.DestinatarioId,
+                        principalTable: "Usuario",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Mensagens_Usuario_RemetenteId",
+                        column: x => x.RemetenteId,
+                        principalTable: "Usuario",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Usuario_Cpf",
+                table: "Usuario",
+                column: "Cpf",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Perfil_Nome",
+                table: "Perfil",
+                column: "Nome",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_DestinatarioId",
+                table: "Mensagens",
+                column: "DestinatarioId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_MensagemPaiId",
+                table: "Mensagens",
+                column: "MensagemPaiId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Mensagens_RemetenteId",
+                table: "Mensagens",
+                column: "RemetenteId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Mensagens");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Usuario_Cpf",
+                table: "Usuario");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Perfil_Nome",
+                table: "Perfil");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SenhaHash",
+                table: "Usuario",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Usuario",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Cpf",
+                table: "Usuario",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(11)",
+                oldMaxLength: 11);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Perfil",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Usuario",
+                table: "Log",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Operacao",
+                table: "Log",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mensagem",
+                table: "Log",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(2000)",
+                oldMaxLength: 2000);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Entidade",
+                table: "Log",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Nome",
+                table: "Funcionalidade",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Valor",
+                table: "Configuracao",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Descricao",
+                table: "Configuracao",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Chave",
+                table: "Configuracao",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Agrupamento",
+                table: "Configuracao",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+        }
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Entities;
-using Sistema.CORE.Repositories.Interfaces;
+using Sistema.CORE.Interfaces;
 using Sistema.INFRA.Data;
 using System.Linq;
 using System.Threading.Tasks;

--- a/3 - Infraestrutura/Sistema.INFRA/Sistema.INFRA.csproj
+++ b/3 - Infraestrutura/Sistema.INFRA/Sistema.INFRA.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Microsoft.Graph" Version="5.91.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- limit string fields such as Nome, Cpf and SenhaHash with `HasMaxLength`
- enforce unique indices for Usuario.Cpf and Perfil.Nome
- add EF Core design-time factory and generate migration

## Testing
- `dotnet ef migrations add AddStringConstraintsAndIndexes --verbose`
- `dotnet ef database update` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server.)*
- `dotnet build` *(fails: The type or namespace name 'IMensagemService' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bdf01218832ca56d7a5eb64abea0