### PR TITLE
Propagate cancellation tokens across services

### DIFF
--- a/0 - Apresentacao/Sistema.API/Controllers/AuthController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/AuthController.cs
@@ -20,7 +20,8 @@ public class AuthController : ControllerBase
     [HttpPost("login")]
     public async Task<ActionResult<string>> Login(LoginDto dto)
     {
-        var token = await _authService.AutenticarAsync(dto.Cpf, dto.Senha);
+        var cancellationToken = HttpContext.RequestAborted;
+        var token = await _authService.AutenticarAsync(dto.Cpf, dto.Senha, cancellationToken);
         if (token is null) return Unauthorized();
         return Ok(token);
     }

--- a/0 - Apresentacao/Sistema.API/Controllers/ConfiguracaoController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/ConfiguracaoController.cs
@@ -22,42 +22,47 @@ public class ConfiguracaoController : ControllerBase
 	}
 
 	[HttpGet("{agrupamento}")]
-	public async Task<IEnumerable<ConfiguracaoDto>> Get(string agrupamento)
-	{
-		var result = await _service.BuscarPorAgrupamentoAsync(agrupamento);
-		return _mapper.Map<IEnumerable<ConfiguracaoDto>>(result);
-	}
+        public async Task<IEnumerable<ConfiguracaoDto>> Get(string agrupamento)
+        {
+                var cancellationToken = HttpContext.RequestAborted;
+                var result = await _service.BuscarPorAgrupamentoAsync(agrupamento, cancellationToken);
+                return _mapper.Map<IEnumerable<ConfiguracaoDto>>(result);
+        }
 
 	[HttpGet("{agrupamento}/{chave}")]
-	public async Task<ActionResult<ConfiguracaoDto>> Get(string agrupamento, string chave)
-	{
-		var entity = await _service.BuscarPorChaveAsync(agrupamento, chave);
-		if (entity is null) return NotFound();
-		return _mapper.Map<ConfiguracaoDto>(entity);
-	}
+        public async Task<ActionResult<ConfiguracaoDto>> Get(string agrupamento, string chave)
+        {
+                var cancellationToken = HttpContext.RequestAborted;
+                var entity = await _service.BuscarPorChaveAsync(agrupamento, chave, cancellationToken);
+                if (entity is null) return NotFound();
+                return _mapper.Map<ConfiguracaoDto>(entity);
+        }
 
 	[HttpPost]
-	public async Task<ActionResult<ConfiguracaoDto>> Post(ConfiguracaoDto dto)
-	{
-		var entity = _mapper.Map<Configuracao>(dto);
-		var result = await _service.AdicionarAsync(entity);
-		var mapped = _mapper.Map<ConfiguracaoDto>(result);
-		return CreatedAtAction(nameof(Get), new { agrupamento = mapped.Agrupamento, chave = mapped.Chave }, mapped);
-	}
+        public async Task<ActionResult<ConfiguracaoDto>> Post(ConfiguracaoDto dto)
+        {
+                var cancellationToken = HttpContext.RequestAborted;
+                var entity = _mapper.Map<Configuracao>(dto);
+                var result = await _service.AdicionarAsync(entity, cancellationToken);
+                var mapped = _mapper.Map<ConfiguracaoDto>(result);
+                return CreatedAtAction(nameof(Get), new { agrupamento = mapped.Agrupamento, chave = mapped.Chave }, mapped);
+        }
 
 	[HttpPut("{id}")]
-	public async Task<IActionResult> Put(int id, ConfiguracaoDto dto)
-	{
-		if (id != dto.Id) return BadRequest();
-		var entity = _mapper.Map<Configuracao>(dto);
-		await _service.AtualizarAsync(entity);
-		return NoContent();
-	}
+        public async Task<IActionResult> Put(int id, ConfiguracaoDto dto)
+        {
+                if (id != dto.Id) return BadRequest();
+                var cancellationToken = HttpContext.RequestAborted;
+                var entity = _mapper.Map<Configuracao>(dto);
+                await _service.AtualizarAsync(entity, cancellationToken);
+                return NoContent();
+        }
 
 	[HttpDelete("{id}")]
-	public async Task<IActionResult> Delete(int id)
-	{
-		await _service.RemoverAsync(id);
-		return NoContent();
-	}
+        public async Task<IActionResult> Delete(int id)
+        {
+                var cancellationToken = HttpContext.RequestAborted;
+                await _service.RemoverAsync(id, cancellationToken);
+                return NoContent();
+        }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/FuncionalidadeController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/FuncionalidadeController.cs
@@ -26,7 +26,8 @@ public class FuncionalidadeController : ControllerBase
     [HttpGet]
     public async Task<PagedResult<FuncionalidadeDto>> Get([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
-        var result = await _service.BuscarPaginadasAsync(page, pageSize);
+        var cancellationToken = HttpContext.RequestAborted;
+        var result = await _service.BuscarPaginadasAsync(page, pageSize, cancellationToken);
         var items = _mapper.Map<IEnumerable<FuncionalidadeDto>>(result.Items);
         return new PagedResult<FuncionalidadeDto>(items, result.TotalCount, result.Page, result.PageSize);
     }
@@ -34,7 +35,8 @@ public class FuncionalidadeController : ControllerBase
     [HttpGet("{id}")]
     public async Task<ActionResult<FuncionalidadeDto>> Get(int id)
     {
-        var obj = await _service.BuscarPorIdAsync(id);
+        var cancellationToken = HttpContext.RequestAborted;
+        var obj = await _service.BuscarPorIdAsync(id, cancellationToken);
         if (obj is null) return NotFound();
         return _mapper.Map<FuncionalidadeDto>(obj);
     }
@@ -42,8 +44,9 @@ public class FuncionalidadeController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<FuncionalidadeDto>> Post(FuncionalidadeDto dto)
     {
+        var cancellationToken = HttpContext.RequestAborted;
         var entity = _mapper.Map<Funcionalidade>(dto);
-        var result = await _service.AdicionarAsync(entity);
+        var result = await _service.AdicionarAsync(entity, cancellationToken);
         return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<FuncionalidadeDto>(result.Data));
     }
 
@@ -51,15 +54,17 @@ public class FuncionalidadeController : ControllerBase
     public async Task<IActionResult> Put(int id, FuncionalidadeDto dto)
     {
         if (id != dto.Id) return BadRequest();
+        var cancellationToken = HttpContext.RequestAborted;
         var entity = _mapper.Map<Funcionalidade>(dto);
-        await _service.AtualizarAsync(entity);
+        await _service.AtualizarAsync(entity, cancellationToken);
         return NoContent();
     }
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {
-        await _service.RemoverAsync(id);
+        var cancellationToken = HttpContext.RequestAborted;
+        await _service.RemoverAsync(id, cancellationToken);
         return NoContent();
     }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
@@ -20,6 +20,7 @@ public class LogController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo)
     {
-        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo);
+        var cancellationToken = HttpContext.RequestAborted;
+        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
     }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
@@ -22,7 +22,8 @@ namespace Sistema.API.Controllers
         [HttpGet("entrada")]
         public async Task<IActionResult> Entrada(int usuarioId, int page = 1, int pageSize = 20, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null)
         {
-            var result = await _mensagemService.BuscarCaixaEntradaAsync(usuarioId, page, pageSize, remetenteId, palavraChave, inicio, fim);
+            var cancellationToken = HttpContext.RequestAborted;
+            var result = await _mensagemService.BuscarCaixaEntradaAsync(usuarioId, page, pageSize, remetenteId, palavraChave, inicio, fim, cancellationToken);
             var dto = result.Items.Select(m => _mapper.Map<MensagemDto>(m));
             return Ok(new { result.TotalItems, result.Page, result.PageSize, Items = dto });
         }
@@ -30,7 +31,8 @@ namespace Sistema.API.Controllers
         [HttpGet("saida")]
         public async Task<IActionResult> Saida(int usuarioId, int page = 1, int pageSize = 20)
         {
-            var result = await _mensagemService.BuscarCaixaSaidaAsync(usuarioId, page, pageSize);
+            var cancellationToken = HttpContext.RequestAborted;
+            var result = await _mensagemService.BuscarCaixaSaidaAsync(usuarioId, page, pageSize, cancellationToken);
             var dto = result.Items.Select(m => _mapper.Map<MensagemDto>(m));
             return Ok(new { result.TotalItems, result.Page, result.PageSize, Items = dto });
         }
@@ -38,7 +40,8 @@ namespace Sistema.API.Controllers
         [HttpGet("{id}")]
         public async Task<IActionResult> Get(int id)
         {
-            var msg = await _mensagemService.BuscarPorIdAsync(id);
+            var cancellationToken = HttpContext.RequestAborted;
+            var msg = await _mensagemService.BuscarPorIdAsync(id, cancellationToken);
             if (msg == null) return NotFound();
             return Ok(_mapper.Map<MensagemDto>(msg));
         }
@@ -46,7 +49,8 @@ namespace Sistema.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] NovaMensagemDto dto)
         {
-            var result = await _mensagemService.EnviarAsync(dto.RemetenteId, dto.DestinatarioId, dto.Assunto, dto.Corpo, dto.MensagemPaiId);
+            var cancellationToken = HttpContext.RequestAborted;
+            var result = await _mensagemService.EnviarAsync(dto.RemetenteId, dto.DestinatarioId, dto.Assunto, dto.Corpo, dto.MensagemPaiId, cancellationToken);
             if (!result.Success) return BadRequest(result.Message);
             return CreatedAtAction(nameof(Get), new { id = result.Data }, result.Data);
         }
@@ -54,7 +58,8 @@ namespace Sistema.API.Controllers
         [HttpPost("{id}/ler")]
         public async Task<IActionResult> MarcarComoLida(int id, int usuarioId)
         {
-            var result = await _mensagemService.MarcarComoLidaAsync(id, usuarioId);
+            var cancellationToken = HttpContext.RequestAborted;
+            var result = await _mensagemService.MarcarComoLidaAsync(id, usuarioId, cancellationToken);
             if (!result.Success) return BadRequest(result.Message);
             return NoContent();
         }

--- a/0 - Apresentacao/Sistema.API/Controllers/PerfilController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/PerfilController.cs
@@ -23,14 +23,16 @@ public class PerfilController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<PerfilDto>> Get(int page = 1, int pageSize = 10)
     {
-        var result = await _service.BuscarTodosAsync(page, pageSize);
+        var cancellationToken = HttpContext.RequestAborted;
+        var result = await _service.BuscarTodosAsync(page, pageSize, cancellationToken);
         return _mapper.Map<IEnumerable<PerfilDto>>(result.Items);
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<PerfilDto>> Get(int id)
     {
-        var perfil = await _service.BuscarPorIdAsync(id);
+        var cancellationToken = HttpContext.RequestAborted;
+        var perfil = await _service.BuscarPorIdAsync(id, cancellationToken);
         if (perfil is null) return NotFound();
         return _mapper.Map<PerfilDto>(perfil);
     }
@@ -38,27 +40,30 @@ public class PerfilController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<PerfilDto>> Post(PerfilDto dto)
     {
-        var perfil = _mapper.Map<Perfil>(dto); 
-        var result = await _service.AdicionarAsync(perfil);
+        var cancellationToken = HttpContext.RequestAborted;
+        var perfil = _mapper.Map<Perfil>(dto);
+        var result = await _service.AdicionarAsync(perfil, cancellationToken);
         if (!result.Success) return BadRequest(result.Message);
-        return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<PerfilDto>(result.Data)); 
+        return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<PerfilDto>(result.Data));
     }
 
     [HttpPut("{id}")]
     public async Task<IActionResult> Put(int id, PerfilDto dto)
     {
         if (id != dto.Id) return BadRequest();
-        var perfil = _mapper.Map<Perfil>(dto); 
-        var result = await _service.AtualizarAsync(perfil);
-        if (!result.Success) return BadRequest(result.Message); 
+        var cancellationToken = HttpContext.RequestAborted;
+        var perfil = _mapper.Map<Perfil>(dto);
+        var result = await _service.AtualizarAsync(perfil, cancellationToken);
+        if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
-    { 
-        var result = await _service.RemoverAsync(id);
-        if (!result.Success) return BadRequest(result.Message); 
+    {
+        var cancellationToken = HttpContext.RequestAborted;
+        var result = await _service.RemoverAsync(id, cancellationToken);
+        if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/UsuarioController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/UsuarioController.cs
@@ -24,14 +24,16 @@ public class UsuarioController : ControllerBase
     [HttpGet]
     public async Task<IEnumerable<UsuarioDto>> Get(int page = 1, int pageSize = 10)
     {
-        var result = await _service.BuscarTodosAsync(page, pageSize);
+        var cancellationToken = HttpContext.RequestAborted;
+        var result = await _service.BuscarTodosAsync(page, pageSize, cancellationToken);
         return _mapper.Map<IEnumerable<UsuarioDto>>(result.Items);
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<UsuarioDto>> Get(int id)
     {
-        var usuario = await _service.BuscarPorIdAsync(id);
+        var cancellationToken = HttpContext.RequestAborted;
+        var usuario = await _service.BuscarPorIdAsync(id, cancellationToken);
         if (usuario is null) return NotFound();
         return _mapper.Map<UsuarioDto>(usuario);
     }
@@ -39,8 +41,9 @@ public class UsuarioController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<UsuarioDto>> Post(UsuarioDto dto)
     {
+        var cancellationToken = HttpContext.RequestAborted;
         var usuario = _mapper.Map<Usuario>(dto);
-        var result = await _service.AdicionarAsync(usuario);
+        var result = await _service.AdicionarAsync(usuario, cancellationToken);
         if (!result.Success) return BadRequest(result.Message);
         return CreatedAtAction(nameof(Get), new { id = result.Data!.Id }, _mapper.Map<UsuarioDto>(result.Data));
     }
@@ -49,8 +52,9 @@ public class UsuarioController : ControllerBase
     public async Task<IActionResult> Put(int id, UsuarioDto dto)
     {
         if (id != dto.Id) return BadRequest();
+        var cancellationToken = HttpContext.RequestAborted;
         var usuario = _mapper.Map<Usuario>(dto);
-        var result = await _service.AtualizarAsync(usuario);
+        var result = await _service.AtualizarAsync(usuario, cancellationToken);
         if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }
@@ -58,7 +62,8 @@ public class UsuarioController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {
-        var result = await _service.RemoverAsync(id);
+        var cancellationToken = HttpContext.RequestAborted;
+        var result = await _service.RemoverAsync(id, cancellationToken);
         if (!result.Success) return BadRequest(result.Message);
         return NoContent();
     }

--- a/2 - Dominio/Sistema.CORE/Services/AuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/AuthService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.CORE.Services;
 
@@ -22,9 +23,9 @@ public class AuthService : IAuthService
         _config = config;
     }
 
-    public async Task<string?> AutenticarAsync(string cpf, string senha)
+    public async Task<string?> AutenticarAsync(string cpf, string senha, CancellationToken cancellationToken = default)
     {
-        var usuario = await _uow.Usuarios.BuscarPorCpfAsync(cpf);
+        var usuario = await _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);
         if (usuario is null || !usuario.Ativo) return null;
         var resultado = _hasher.VerifyHashedPassword(usuario, usuario.SenhaHash, senha);
         if (resultado == PasswordVerificationResult.Failed) return null;

--- a/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 
@@ -12,28 +14,28 @@ public class ConfiguracaoService : IConfiguracaoService
         _uow = uow;
     }
 
-    public Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento) =>
-        _uow.Configuracoes.BuscarPorAgrupamentoAsync(agrupamento);
+    public Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default) =>
+        _uow.Configuracoes.BuscarPorAgrupamentoAsync(agrupamento, cancellationToken);
 
-    public Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave) =>
-        _uow.Configuracoes.BuscarPorChaveAsync(agrupamento, chave);
+    public Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default) =>
+        _uow.Configuracoes.BuscarPorChaveAsync(agrupamento, chave, cancellationToken);
 
-    public async Task<Configuracao> AdicionarAsync(Configuracao config)
+    public async Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default)
     {
-        var result = await _uow.Configuracoes.AdicionarAsync(config);
-        await _uow.ConfirmarAsync();
+        var result = await _uow.Configuracoes.AdicionarAsync(config, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return result;
     }
 
-    public async Task AtualizarAsync(Configuracao config)
+    public async Task AtualizarAsync(Configuracao config, CancellationToken cancellationToken = default)
     {
         await _uow.Configuracoes.AtualizarAsync(config);
-        await _uow.ConfirmarAsync();
+        await _uow.ConfirmarAsync(cancellationToken);
     }
 
-    public async Task RemoverAsync(int id)
+    public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Configuracoes.RemoverAsync(id);
-        await _uow.ConfirmarAsync();
+        await _uow.Configuracoes.RemoverAsync(id, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
@@ -15,32 +17,32 @@ public class FuncionalidadeService : IFuncionalidadeService
         _log = log;
     }
 
-    public Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize)
-        => _uow.Funcionalidades.BuscarPaginadasAsync(page, pageSize);
+    public Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default)
+        => _uow.Funcionalidades.BuscarPaginadasAsync(page, pageSize, cancellationToken);
 
-    public Task<Funcionalidade?> BuscarPorIdAsync(int id) => _uow.Funcionalidades.BuscarPorIdAsync(id);
+    public Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Funcionalidades.BuscarPorIdAsync(id, cancellationToken);
 
-    public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func)
+    public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
-        await _uow.Funcionalidades.AdicionarAsync(func);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Add", true, "Funcionalidade criada", LogTipo.Sucesso, func.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        await _uow.Funcionalidades.AdicionarAsync(func, cancellationToken);
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Add", true, "Funcionalidade criada", LogTipo.Sucesso, func.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Funcionalidade>(true, "Criado", func);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Funcionalidade func)
+    public async Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
         await _uow.Funcionalidades.AtualizarAsync(func);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Update", true, "Funcionalidade atualizada", LogTipo.Sucesso, func.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Update", true, "Funcionalidade atualizada", LogTipo.Sucesso, func.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Atualizado");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Funcionalidades.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Delete", true, "Funcionalidade removida", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Funcionalidades.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Delete", true, "Funcionalidade removida", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IAuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IAuthService.cs
@@ -1,8 +1,9 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IAuthService
 {
-    Task<string?> AutenticarAsync(string cpf, string senha);
+    Task<string?> AutenticarAsync(string cpf, string senha, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
@@ -1,12 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IConfiguracaoService
 {
-    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento);
-    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave);
-    Task<Configuracao> AdicionarAsync(Configuracao config);
-    Task AtualizarAsync(Configuracao config);
-    Task RemoverAsync(int id);
+    Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default);
+    Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default);
+    Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default);
+    Task AtualizarAsync(Configuracao config, CancellationToken cancellationToken = default);
+    Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IEmailService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IEmailService.cs
@@ -1,8 +1,9 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface IEmailService
 {
-    Task EnviarAsync(string destinatario, string assunto, string mensagem);
+    Task EnviarAsync(string destinatario, string assunto, string mensagem, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 
@@ -5,9 +7,9 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IFuncionalidadeService
 {
-    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize);
-    Task<Funcionalidade?> BuscarPorIdAsync(int id);
-    Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func);
-    Task<OperationResult> AtualizarAsync(Funcionalidade func);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/ILogService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/ILogService.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Interfaces;
@@ -5,10 +8,10 @@ namespace Sistema.CORE.Interfaces;
 public interface ILogService
 {
 
-    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo);
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
 
 
 
-    Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null);
+    Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
@@ -1,16 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
-using System;
-using System.Threading.Tasks;
 
 namespace Sistema.CORE.Services.Interfaces
 {
     public interface IMensagemService
     {
-        Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null);
-        Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize);
-        Task<Mensagem?> BuscarPorIdAsync(int id);
-        Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null);
-        Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId);
+        Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null, CancellationToken cancellationToken = default);
+        Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize, CancellationToken cancellationToken = default);
+        Task<Mensagem?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+        Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default);
+        Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId, CancellationToken cancellationToken = default);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IPerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IPerfilService.cs
@@ -1,13 +1,15 @@
 namespace Sistema.CORE.Interfaces;
 
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
 
 public interface IPerfilService
 {
-    Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize);
-    Task<Perfil?> BuscarPorIdAsync(int id);
-    Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil);
-    Task<OperationResult> AtualizarAsync(Perfil perfil);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Perfil?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Perfil perfil, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/ITemaService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/ITemaService.cs
@@ -1,10 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface ITemaService
 {
-    Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId);
-    Task SalvarAsync(Tema tema);
+    Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId, CancellationToken cancellationToken = default);
+    Task SalvarAsync(Tema tema, CancellationToken cancellationToken = default);
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
 
@@ -5,10 +7,10 @@ namespace Sistema.CORE.Interfaces;
 
 public interface IUsuarioService
 {
-    Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize);
-    Task<Usuario?> BuscarPorIdAsync(int id);
-    Task<Usuario?> BuscarPorCpfAsync(string cpf);
-    Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario);
-    Task<OperationResult> AtualizarAsync(Usuario usuario);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default);
+    Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/LogService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/LogService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 
@@ -13,9 +15,9 @@ public class LogService : ILogService
     }
 
 
-    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo)
-        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo);
-    public Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null)
+    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
+    public Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
     {
         return _uow.Logs.AdicionarAsync(new Log
         {
@@ -26,7 +28,7 @@ public class LogService : ILogService
             Tipo = tipo,
             Usuario = usuario,
             Detalhe = detalhe
-        });
+        }, cancellationToken);
     }
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
@@ -15,48 +17,48 @@ public class PerfilService : IPerfilService
         _log = log;
     }
 
-public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize) =>
-    _uow.Perfis.BuscarTodosAsync(page, pageSize);
+    public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default) =>
+        _uow.Perfis.BuscarTodosAsync(page, pageSize, cancellationToken);
 
-    public Task<Perfil?> BuscarPorIdAsync(int id) => _uow.Perfis.BuscarPorIdAsync(id);
+    public Task<Perfil?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Perfis.BuscarPorIdAsync(id, cancellationToken);
 
-    public async Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil)
+    public async Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome, cancellationToken);
         if (existing is not null)
         {
-            await _log.RegistrarAsync(nameof(Perfil), "Add", false, "Perfil já existe", LogTipo.Erro, perfil.UsuarioInclusao);
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Perfil), "Add", false, "Perfil já existe", LogTipo.Erro, perfil.UsuarioInclusao, cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult<Perfil>(false, "Perfil já existe");
         }
 
-        var created = await _uow.Perfis.AdicionarAsync(perfil);
-        await _log.RegistrarAsync(nameof(Perfil), "Add", true, "Perfil criado", LogTipo.Sucesso, perfil.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        var created = await _uow.Perfis.AdicionarAsync(perfil, cancellationToken);
+        await _log.RegistrarAsync(nameof(Perfil), "Add", true, "Perfil criado", LogTipo.Sucesso, perfil.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Perfil>(true, "Perfil criado com sucesso", created);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Perfil perfil)
+    public async Task<OperationResult> AtualizarAsync(Perfil perfil, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome, cancellationToken);
         if (existing is not null && existing.Id != perfil.Id)
         {
-            await _log.RegistrarAsync(nameof(Perfil), "Update", false, "Nome já utilizado", LogTipo.Erro, perfil.UsuarioAlteracao ?? "system");
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Perfil), "Update", false, "Nome já utilizado", LogTipo.Erro, perfil.UsuarioAlteracao ?? "system", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult(false, "Nome já utilizado");
         }
 
         await _uow.Perfis.AtualizarAsync(perfil);
-        await _log.RegistrarAsync(nameof(Perfil), "Update", true, "Perfil atualizado", LogTipo.Sucesso, perfil.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Perfil), "Update", true, "Perfil atualizado", LogTipo.Sucesso, perfil.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Perfil atualizado com sucesso");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Perfis.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Perfil), "Delete", true, "Perfil removido", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Perfis.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Perfil), "Delete", true, "Perfil removido", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Perfil removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/TemaService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/TemaService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
 
@@ -12,15 +14,15 @@ public class TemaService : ITemaService
         _uow = uow;
     }
 
-    public Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId) =>
-        _uow.Temas.BuscarPorUsuarioIdAsync(usuarioId);
+    public Task<Tema?> BuscarPorUsuarioIdAsync(int usuarioId, CancellationToken cancellationToken = default) =>
+        _uow.Temas.BuscarPorUsuarioIdAsync(usuarioId, cancellationToken);
 
-    public async Task SalvarAsync(Tema tema)
+    public async Task SalvarAsync(Tema tema, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Temas.BuscarPorUsuarioIdAsync(tema.UsuarioId);
+        var existing = await _uow.Temas.BuscarPorUsuarioIdAsync(tema.UsuarioId, cancellationToken);
         if (existing is null)
         {
-            await _uow.Temas.AdicionarAsync(tema);
+            await _uow.Temas.AdicionarAsync(tema, cancellationToken);
         }
         else
         {
@@ -35,7 +37,7 @@ public class TemaService : ITemaService
             existing.UsuarioAlteracao = tema.UsuarioAlteracao;
             await _uow.Temas.AtualizarAsync(existing);
         }
-        await _uow.ConfirmarAsync();
+        await _uow.ConfirmarAsync(cancellationToken);
     }
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
@@ -15,50 +17,50 @@ public class UsuarioService : IUsuarioService
         _log = log;
     }
 
-    public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize) =>
-        _uow.Usuarios.BuscarTodosAsync(page, pageSize);
+    public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default) =>
+        _uow.Usuarios.BuscarTodosAsync(page, pageSize, cancellationToken);
 
-    public Task<Usuario?> BuscarPorIdAsync(int id) => _uow.Usuarios.BuscarPorIdAsync(id);
+    public Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorIdAsync(id, cancellationToken);
 
-    public Task<Usuario?> BuscarPorCpfAsync(string cpf) => _uow.Usuarios.BuscarPorCpfAsync(cpf);
+    public Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);
 
-    public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario)
+    public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
         if (existing is not null)
         {
-            await _log.RegistrarAsync(nameof(Usuario), "Add", false, "Usuário já existe", LogTipo.Erro, usuario.UsuarioInclusao);
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Usuario), "Add", false, "Usuário já existe", LogTipo.Erro, usuario.UsuarioInclusao, cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult<Usuario>(false, "Usuário já existe");
         }
 
-        var created = await _uow.Usuarios.AdicionarAsync(usuario);
-        await _log.RegistrarAsync(nameof(Usuario), "Add", true, "Usuário criado", LogTipo.Sucesso, usuario.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        var created = await _uow.Usuarios.AdicionarAsync(usuario, cancellationToken);
+        await _log.RegistrarAsync(nameof(Usuario), "Add", true, "Usuário criado", LogTipo.Sucesso, usuario.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Usuario>(true, "Usuário criado com sucesso", created);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Usuario usuario)
+    public async Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
         if (existing is not null && existing.Id != usuario.Id)
         {
-            await _log.RegistrarAsync(nameof(Usuario), "Update", false, "CPF já utilizado", LogTipo.Erro, usuario.UsuarioAlteracao ?? "system");
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Usuario), "Update", false, "CPF já utilizado", LogTipo.Erro, usuario.UsuarioAlteracao ?? "system", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult(false, "CPF já utilizado");
         }
 
         await _uow.Usuarios.AtualizarAsync(usuario);
-        await _log.RegistrarAsync(nameof(Usuario), "Update", true, "Usuário atualizado", LogTipo.Sucesso, usuario.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Usuario), "Update", true, "Usuário atualizado", LogTipo.Sucesso, usuario.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Usuário atualizado com sucesso");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Usuarios.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Usuario), "Delete", true, "Usuário removido", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Usuarios.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Usuario), "Delete", true, "Usuário removido", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Usuário removido");
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Services/EmailService.cs
@@ -5,6 +5,7 @@ using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Users.Item.SendMail;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.INFRA.Services;
 
@@ -19,7 +20,7 @@ public class EmailService : IEmailService
         _logger = logger;
     }
 
-    public async Task EnviarAsync(string destinatario, string assunto, string mensagem)
+    public async Task EnviarAsync(string destinatario, string assunto, string mensagem, CancellationToken cancellationToken = default)
     {
         var tenantId = _options.TenantId;
         var clientId = _options.ClientId;
@@ -57,7 +58,7 @@ public class EmailService : IEmailService
 
         try
         {
-            await graphClient.Users[sender].SendMail.PostAsync(request);
+            await graphClient.Users[sender].SendMail.PostAsync(request, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- add optional CancellationToken parameters to service interfaces
- propagate cancellation tokens through service implementations and repositories
- pass HttpContext.RequestAborted from API controllers

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c45bd8b8832cba49ff175fa044f2