### PR TITLE
Propaga CancellationToken no serviço de logs

### DIFF
--- a/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Sistema.CORE.Interfaces;
 using Sistema.CORE.Entities;
 using Microsoft.AspNetCore.Authorization;
+using System.Threading;
 
 namespace Sistema.API.Controllers;
 
@@ -18,8 +19,8 @@ public class LogController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo)
+    public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, CancellationToken cancellationToken)
     {
-        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo);
+        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
@@ -1,6 +1,7 @@
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.CORE.Services;
 
@@ -20,27 +21,27 @@ public class FuncionalidadeService : IFuncionalidadeService
 
     public Task<Funcionalidade?> BuscarPorIdAsync(int id) => _uow.Funcionalidades.BuscarPorIdAsync(id);
 
-    public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func)
+    public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
-        await _uow.Funcionalidades.AdicionarAsync(func);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Add", true, "Funcionalidade criada", LogTipo.Sucesso, func.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        await _uow.Funcionalidades.AdicionarAsync(func, cancellationToken);
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Add", true, "Funcionalidade criada", LogTipo.Sucesso, func.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Funcionalidade>(true, "Criado", func);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Funcionalidade func)
+    public async Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
         await _uow.Funcionalidades.AtualizarAsync(func);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Update", true, "Funcionalidade atualizada", LogTipo.Sucesso, func.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Update", true, "Funcionalidade atualizada", LogTipo.Sucesso, func.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Atualizado");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Funcionalidades.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Funcionalidade), "Delete", true, "Funcionalidade removida", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Funcionalidades.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Funcionalidade), "Delete", true, "Funcionalidade removida", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
@@ -1,5 +1,6 @@
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
@@ -7,7 +8,7 @@ public interface IFuncionalidadeService
 {
     Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize);
     Task<Funcionalidade?> BuscarPorIdAsync(int id);
-    Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func);
-    Task<OperationResult> AtualizarAsync(Funcionalidade func);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/ILogService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/ILogService.cs
@@ -1,14 +1,12 @@
 using Sistema.CORE.Entities;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
 public interface ILogService
 {
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
 
-    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo);
-
-
-
-    Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null);
+    Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IPerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IPerfilService.cs
@@ -2,12 +2,13 @@ namespace Sistema.CORE.Interfaces;
 
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
+using System.Threading;
 
 public interface IPerfilService
 {
     Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize);
     Task<Perfil?> BuscarPorIdAsync(int id);
-    Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil);
-    Task<OperationResult> AtualizarAsync(Perfil perfil);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Perfil perfil, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
@@ -1,5 +1,6 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Common;
+using System.Threading;
 
 namespace Sistema.CORE.Interfaces;
 
@@ -8,7 +9,7 @@ public interface IUsuarioService
     Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize);
     Task<Usuario?> BuscarPorIdAsync(int id);
     Task<Usuario?> BuscarPorCpfAsync(string cpf);
-    Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario);
-    Task<OperationResult> AtualizarAsync(Usuario usuario);
-    Task<OperationResult> RemoverAsync(int id);
+    Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+    Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+    Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/LogService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/LogService.cs
@@ -1,5 +1,6 @@
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.CORE.Services;
 
@@ -11,11 +12,10 @@ public class LogService : ILogService
     {
         _uow = uow;
     }
+    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
 
-
-    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo)
-        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo);
-    public Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null)
+    public Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
     {
         return _uow.Logs.AdicionarAsync(new Log
         {
@@ -26,7 +26,7 @@ public class LogService : ILogService
             Tipo = tipo,
             Usuario = usuario,
             Detalhe = detalhe
-        });
+        }, cancellationToken);
     }
 }
 

--- a/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/PerfilService.cs
@@ -1,6 +1,7 @@
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.CORE.Services;
 
@@ -15,48 +16,48 @@ public class PerfilService : IPerfilService
         _log = log;
     }
 
-public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize) =>
-    _uow.Perfis.BuscarTodosAsync(page, pageSize);
+    public Task<PagedResult<Perfil>> BuscarTodosAsync(int page, int pageSize) =>
+        _uow.Perfis.BuscarTodosAsync(page, pageSize);
 
     public Task<Perfil?> BuscarPorIdAsync(int id) => _uow.Perfis.BuscarPorIdAsync(id);
 
-    public async Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil)
+    public async Task<OperationResult<Perfil>> AdicionarAsync(Perfil perfil, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome, cancellationToken);
         if (existing is not null)
         {
-            await _log.RegistrarAsync(nameof(Perfil), "Add", false, "Perfil já existe", LogTipo.Erro, perfil.UsuarioInclusao);
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Perfil), "Add", false, "Perfil já existe", LogTipo.Erro, perfil.UsuarioInclusao, cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult<Perfil>(false, "Perfil já existe");
         }
 
-        var created = await _uow.Perfis.AdicionarAsync(perfil);
-        await _log.RegistrarAsync(nameof(Perfil), "Add", true, "Perfil criado", LogTipo.Sucesso, perfil.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        var created = await _uow.Perfis.AdicionarAsync(perfil, cancellationToken);
+        await _log.RegistrarAsync(nameof(Perfil), "Add", true, "Perfil criado", LogTipo.Sucesso, perfil.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Perfil>(true, "Perfil criado com sucesso", created);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Perfil perfil)
+    public async Task<OperationResult> AtualizarAsync(Perfil perfil, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome);
+        var existing = await _uow.Perfis.BuscarPorNomeAsync(perfil.Nome, cancellationToken);
         if (existing is not null && existing.Id != perfil.Id)
         {
-            await _log.RegistrarAsync(nameof(Perfil), "Update", false, "Nome já utilizado", LogTipo.Erro, perfil.UsuarioAlteracao ?? "system");
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Perfil), "Update", false, "Nome já utilizado", LogTipo.Erro, perfil.UsuarioAlteracao ?? "system", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult(false, "Nome já utilizado");
         }
 
         await _uow.Perfis.AtualizarAsync(perfil);
-        await _log.RegistrarAsync(nameof(Perfil), "Update", true, "Perfil atualizado", LogTipo.Sucesso, perfil.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Perfil), "Update", true, "Perfil atualizado", LogTipo.Sucesso, perfil.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Perfil atualizado com sucesso");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Perfis.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Perfil), "Delete", true, "Perfil removido", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Perfis.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Perfil), "Delete", true, "Perfil removido", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Perfil removido");
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -1,6 +1,7 @@
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Interfaces;
+using System.Threading;
 
 namespace Sistema.CORE.Services;
 
@@ -22,43 +23,43 @@ public class UsuarioService : IUsuarioService
 
     public Task<Usuario?> BuscarPorCpfAsync(string cpf) => _uow.Usuarios.BuscarPorCpfAsync(cpf);
 
-    public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario)
+    public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
         if (existing is not null)
         {
-            await _log.RegistrarAsync(nameof(Usuario), "Add", false, "Usuário já existe", LogTipo.Erro, usuario.UsuarioInclusao);
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Usuario), "Add", false, "Usuário já existe", LogTipo.Erro, usuario.UsuarioInclusao, cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult<Usuario>(false, "Usuário já existe");
         }
 
-        var created = await _uow.Usuarios.AdicionarAsync(usuario);
-        await _log.RegistrarAsync(nameof(Usuario), "Add", true, "Usuário criado", LogTipo.Sucesso, usuario.UsuarioInclusao);
-        await _uow.ConfirmarAsync();
+        var created = await _uow.Usuarios.AdicionarAsync(usuario, cancellationToken);
+        await _log.RegistrarAsync(nameof(Usuario), "Add", true, "Usuário criado", LogTipo.Sucesso, usuario.UsuarioInclusao, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<Usuario>(true, "Usuário criado com sucesso", created);
     }
 
-    public async Task<OperationResult> AtualizarAsync(Usuario usuario)
+    public async Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
-        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf);
+        var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
         if (existing is not null && existing.Id != usuario.Id)
         {
-            await _log.RegistrarAsync(nameof(Usuario), "Update", false, "CPF já utilizado", LogTipo.Erro, usuario.UsuarioAlteracao ?? "system");
-            await _uow.ConfirmarAsync();
+            await _log.RegistrarAsync(nameof(Usuario), "Update", false, "CPF já utilizado", LogTipo.Erro, usuario.UsuarioAlteracao ?? "system", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
             return new OperationResult(false, "CPF já utilizado");
         }
 
         await _uow.Usuarios.AtualizarAsync(usuario);
-        await _log.RegistrarAsync(nameof(Usuario), "Update", true, "Usuário atualizado", LogTipo.Sucesso, usuario.UsuarioAlteracao ?? "system");
-        await _uow.ConfirmarAsync();
+        await _log.RegistrarAsync(nameof(Usuario), "Update", true, "Usuário atualizado", LogTipo.Sucesso, usuario.UsuarioAlteracao ?? "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Usuário atualizado com sucesso");
     }
 
-    public async Task<OperationResult> RemoverAsync(int id)
+    public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
-        await _uow.Usuarios.RemoverAsync(id);
-        await _log.RegistrarAsync(nameof(Usuario), "Delete", true, "Usuário removido", LogTipo.Sucesso, "system");
-        await _uow.ConfirmarAsync();
+        await _uow.Usuarios.RemoverAsync(id, cancellationToken);
+        await _log.RegistrarAsync(nameof(Usuario), "Delete", true, "Usuário removido", LogTipo.Sucesso, "system", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, "Usuário removido");
     }
 }


### PR DESCRIPTION
## Summary
- adiciona CancellationToken às assinaturas de ILogService e implementações
- propaga o token aos serviços de domínio (Usuário, Perfil e Funcionalidade)
- expõe token no controlador de logs para encaminhar cancelamento

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c48e8ad4832cac6a4c33e98f70d9