### PR TITLE
Implement password reset token flow

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Models/ResetPasswordViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/ResetPasswordViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sistema.MVC.Models;
+
+public class ResetPasswordViewModel
+{
+    [Required]
+    public string Token { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    [Display(Name = "Nova Senha")]
+    public string Senha { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    [Display(Name = "Confirmar Senha")]
+    [Compare("Senha", ErrorMessage = "As senhas não conferem")]
+    public string ConfirmacaoSenha { get; set; } = string.Empty;
+}

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/ResetPassword.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/ResetPassword.cshtml
@@ -1,0 +1,38 @@
+@model Sistema.MVC.Models.ResetPasswordViewModel
+@{
+    Layout = null;
+    ViewData["Title"] = "Redefinir Senha";
+}
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Sistema</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body>
+    <div class="container mt-5">
+        <h2 class="mb-4 text-center">@ViewData["Title"]</h2>
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <form asp-action="ResetPassword" method="post">
+            <input type="hidden" asp-for="Token" />
+            <div class="mb-3">
+                <label asp-for="Senha" class="form-label"></label>
+                <input asp-for="Senha" class="form-control" />
+                <span asp-validation-for="Senha" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="ConfirmacaoSenha" class="form-label"></label>
+                <input asp-for="ConfirmacaoSenha" class="form-control" />
+                <span asp-validation-for="ConfirmacaoSenha" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Redefinir Senha</button>
+        </form>
+    </div>
+    <script src="~/lib/jquery/dist/jquery.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+    @await Html.PartialAsync("_ValidationScriptsPartial")
+</body>
+</html>

--- a/2 - Dominio/Sistema.CORE/Entities/Usuario.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Usuario.cs
@@ -9,4 +9,6 @@ public class Usuario : AuditableEntity
     public string SenhaHash { get; set; } = string.Empty;
     public int PerfilId { get; set; }
     public Perfil? Perfil { get; set; }
+    public string? ResetToken { get; set; }
+    public DateTime? ResetTokenExpiration { get; set; }
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
@@ -10,6 +10,7 @@ public interface IUsuarioRepository
     Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
     Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default);
     Task<bool> ExisteAtivoPorPerfilAsync(int perfilId, CancellationToken cancellationToken = default);
     Task<Usuario> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
     Task AtualizarAsync(Usuario usuario);

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
@@ -14,6 +14,7 @@ public interface IUsuarioService
     Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
     Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
     Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default);
+    Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default);
     Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
     Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default);
     Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -25,6 +25,8 @@ public class UsuarioService : IUsuarioService
 
     public Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);
 
+    public Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorResetTokenAsync(token, cancellationToken);
+
     public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
         var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/UsuarioMap.cs
@@ -14,6 +14,8 @@ public class UsuarioMap : IEntityTypeConfiguration<Usuario>
         builder.Property(u => u.Cpf).IsRequired().HasMaxLength(11);
         builder.Property(u => u.SenhaHash).IsRequired().HasMaxLength(255);
         builder.Property(u => u.Ativo).HasDefaultValue(true);
+        builder.Property(u => u.ResetToken).HasMaxLength(100);
+        builder.Property(u => u.ResetTokenExpiration);
 
         builder.HasIndex(u => u.Cpf).IsUnique();
 

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
@@ -4,6 +4,7 @@ using Sistema.CORE.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.INFRA.Data;
 using System.Linq;
+using System;
 using System.Threading;
 
 namespace Sistema.INFRA.Repositories;
@@ -61,6 +62,13 @@ public class UsuarioRepository : IUsuarioRepository
         return await _context.Usuarios
             .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Cpf == cpf, cancellationToken);
+    }
+
+    public async Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        return await _context.Usuarios
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ResetToken == token && u.ResetTokenExpiration > DateTime.UtcNow, cancellationToken);
     }
 
     public async Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- avoid sending passwords in clear text during registration
- send password reset token and link via email
- add ResetPassword action and view to validate token and set new password

## Testing
- `dotnet build` *(fails: multiple compilation errors in services)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ccc51a1c832c8c810d9c39f4eb89