### PR TITLE
Adiciona dashboard inicial com cards de estatísticas

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Controllers/HomeController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/HomeController.cs
@@ -1,22 +1,62 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Sistema.MVC.Models;
+using Sistema.CORE.Interfaces;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Sistema.MVC.Controllers
 {
-	public class HomeController : Controller
-	{
-		private readonly ILogger<HomeController> _logger;
+        public class HomeController : Controller
+        {
+                private readonly ILogger<HomeController> _logger;
+                private readonly IUsuarioService _usuarioService;
+                private readonly IPerfilService _perfilService;
+                private readonly IFuncionalidadeService _funcionalidadeService;
+                private readonly IConfiguracaoService _configuracaoService;
+                private readonly IMensagemService _mensagemService;
 
-		public HomeController(ILogger<HomeController> logger)
-		{
-			_logger = logger;
-		}
+                public HomeController(
+                        ILogger<HomeController> logger,
+                        IUsuarioService usuarioService,
+                        IPerfilService perfilService,
+                        IFuncionalidadeService funcionalidadeService,
+                        IConfiguracaoService configuracaoService,
+                        IMensagemService mensagemService)
+                {
+                        _logger = logger;
+                        _usuarioService = usuarioService;
+                        _perfilService = perfilService;
+                        _funcionalidadeService = funcionalidadeService;
+                        _configuracaoService = configuracaoService;
+                        _mensagemService = mensagemService;
+                }
 
-		public IActionResult Index()
-		{
-			return View();
-		}
+                public async Task<IActionResult> Index()
+                {
+                        var model = new DashboardViewModel();
+
+                        var usuarios = await _usuarioService.BuscarTodosAsync(1, 1);
+                        model.TotalUsuarios = usuarios.TotalCount;
+
+                        var perfis = await _perfilService.BuscarTodosAsync(1, 1);
+                        model.TotalPerfis = perfis.TotalCount;
+
+                        var funcs = await _funcionalidadeService.BuscarPaginadasAsync(1, 1);
+                        model.TotalFuncionalidades = funcs.TotalCount;
+
+                        var configs = await _configuracaoService.BuscarPorAgrupamentoAsync("AzureAd");
+                        model.TotalConfiguracoes = configs.Count();
+
+                        var userId = HttpContext.Session.GetInt32("UserId");
+                        if (userId is not null)
+                        {
+                                var msgs = await _mensagemService.BuscarCaixaEntradaAsync(userId.Value, 1, 1);
+                                model.TotalMensagens = msgs.TotalCount;
+                        }
+
+                        return View(model);
+                }
 
 		public IActionResult Privacy()
 		{

--- a/0 - Apresentacao/Sistema.MVC/Models/DashboardViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/DashboardViewModel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Sistema.MVC.Models
+{
+    public class DashboardViewModel
+    {
+        public int TotalUsuarios { get; set; }
+        public int TotalPerfis { get; set; }
+        public int TotalFuncionalidades { get; set; }
+        public int TotalConfiguracoes { get; set; }
+        public int TotalMensagens { get; set; }
+    }
+}

--- a/0 - Apresentacao/Sistema.MVC/Views/Home/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Home/Index.cshtml
@@ -1,10 +1,47 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@model Sistema.MVC.Models.DashboardViewModel
+@{
+    ViewData["Title"] = "Dashboard";
 }
 
-<div class="card">
-    <div class="card-body text-center">
-        <h1 class="display-4">Bem-vindo!</h1>
-        <p>Selecione uma funcionalidade no menu lateral.</p>
+<div class="row">
+    <div class="col-md-3 mb-3">
+        <div class="card text-bg-primary text-center">
+            <div class="card-body">
+                <h5 class="card-title">Usuários</h5>
+                <p class="display-6">@Model.TotalUsuarios</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 mb-3">
+        <div class="card text-bg-success text-center">
+            <div class="card-body">
+                <h5 class="card-title">Perfis</h5>
+                <p class="display-6">@Model.TotalPerfis</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 mb-3">
+        <div class="card text-bg-info text-center">
+            <div class="card-body">
+                <h5 class="card-title">Funcionalidades</h5>
+                <p class="display-6">@Model.TotalFuncionalidades</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 mb-3">
+        <div class="card text-bg-warning text-center">
+            <div class="card-body">
+                <h5 class="card-title">Configurações</h5>
+                <p class="display-6">@Model.TotalConfiguracoes</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 mb-3">
+        <div class="card text-bg-secondary text-center">
+            <div class="card-body">
+                <h5 class="card-title">Mensagens</h5>
+                <p class="display-6">@Model.TotalMensagens</p>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Resumo
- adiciona `DashboardViewModel` para agrupar contadores de dados
- atualiza `HomeController` para obter totais de usuários, perfis, funcionalidades, configurações e mensagens
- substitui a view `Index` por um dashboard com cards exibindo os contadores

## Testes
- `dotnet build` *(falha: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cdafebf8832c89ce930e9500c067