### PR TITLE
chore: remove unused import map

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -45,7 +45,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Sistema.MVC</title>
-    <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/Sistema.MVC.styles.css" asp-append-version="true" />


### PR DESCRIPTION
## Summary
- remove empty import map tag from layout since import maps aren't used

## Testing
- `dotnet build`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ee3db054832ca456fdfc852a9399