### PR TITLE
feat: support dark color scheme and theme persistence

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
@@ -5,7 +5,7 @@
 }
 
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-br" style="color-scheme: light dark;">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/ResetPassword.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/ResetPassword.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Redefinir Senha";
 }
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-br" style="color-scheme: light dark;">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -40,7 +40,7 @@
     string footerFixedClass = footerFixo ? "fixed-bottom" : string.Empty;
 }
 <!DOCTYPE html>
-<html lang="en" style="--header-bg:@headerColor; --sidebar-bg:@leftColor; --rightbar-bg:@rightColor; --footer-bg:@footerColor;">
+<html lang="en" style="color-scheme: light dark; --header-bg:@headerColor; --sidebar-bg:@leftColor; --rightbar-bg:@rightColor; --footer-bg:@footerColor;">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
@@ -9,6 +9,15 @@
   --footer-bg: #{v.$azul};
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --header-bg: #212529;
+    --sidebar-bg: #212529;
+    --rightbar-bg: #343a40;
+    --footer-bg: #212529;
+  }
+}
+
 .header-bg { background-color: var(--header-bg) !important; }
 .sidebar-bg { background-color: var(--sidebar-bg) !important; }
 .rightbar-bg { background-color: var(--rightbar-bg) !important; }

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -28,6 +28,19 @@ window.showInfo = function (message) {
 };
 
 document.addEventListener('DOMContentLoaded', function () {
+    var root = document.documentElement;
+    var savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+        root.dataset.theme = savedTheme;
+        if (savedTheme === 'dark') {
+            document.body.classList.remove('bg-light', 'text-dark');
+            document.body.classList.add('bg-dark', 'text-white');
+        } else {
+            document.body.classList.remove('bg-dark', 'text-white');
+            document.body.classList.add('bg-light', 'text-dark');
+        }
+    }
+
     var temaToggle = document.getElementById('temaToggle');
     var temaSidebar = document.getElementById('temaSidebar');
     if (temaToggle && temaSidebar) {
@@ -56,7 +69,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.querySelectorAll('input[name="ModoEscuro"]').forEach(function (radio) {
         radio.addEventListener('change', function () {
-            if (this.value === 'true') {
+            var theme = this.value === 'true' ? 'dark' : 'light';
+            root.dataset.theme = theme;
+            localStorage.setItem('theme', theme);
+            if (theme === 'dark') {
                 document.body.classList.remove('bg-light', 'text-dark');
                 document.body.classList.add('bg-dark', 'text-white');
             } else {
@@ -65,8 +81,6 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     });
-
-    var root = document.documentElement;
 
     var headerInput = document.getElementById('CorHeader');
     if (headerInput) {


### PR DESCRIPTION
## Summary
- adjust site styles for prefers-color-scheme dark
- persist manual theme selection on document element
- declare color-scheme on root html elements

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b501a4bd64832cbac3c53c993cd6af