### PR TITLE
Collapse sidebar on small screens and sync toggle

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
@@ -99,6 +99,37 @@ footer.footer {
   display: inline;
 }
 
+@media (max-width: 768px) {
+  .sidebar {
+    width: 60px;
+  }
+
+  .sidebar .nav-link span {
+    display: none;
+  }
+
+  .sidebar .nav-link {
+    text-align: center;
+  }
+
+  .sidebar .nav-link i {
+    margin-right: 0;
+  }
+
+  .sidebar:hover {
+    width: 200px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+  }
+
+  .sidebar:hover .nav-link span {
+    display: inline;
+  }
+}
+
 body.bg-dark .card {
   background-color: #2c2f33;
   color: #f8f9fa;

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -44,14 +44,33 @@ document.addEventListener('DOMContentLoaded', function () {
     var menuToggle = document.getElementById('menuToggle');
     var leftSidebar = document.querySelector('aside.sidebar');
     var menuCheckbox = document.getElementById('MenuLateralExpandido');
+    var syncMenu = function () {
+        if (!leftSidebar) return;
+        if (window.innerWidth <= 768) {
+            leftSidebar.classList.add('collapsed');
+            if (menuCheckbox) {
+                menuCheckbox.checked = false;
+            }
+        } else if (menuCheckbox) {
+            leftSidebar.classList.toggle('collapsed', !menuCheckbox.checked);
+        } else {
+            leftSidebar.classList.remove('collapsed');
+        }
+    };
+
     if (menuToggle && leftSidebar) {
         menuToggle.addEventListener('click', function () {
             leftSidebar.classList.toggle('collapsed');
             if (menuCheckbox) {
                 menuCheckbox.checked = !leftSidebar.classList.contains('collapsed');
             }
+            syncMenu();
         });
     }
+
+    window.addEventListener('resize', syncMenu);
+    syncMenu();
+
     AOS.init();
 
     document.querySelectorAll('input[name="ModoEscuro"]').forEach(function (radio) {
@@ -117,8 +136,6 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     if (menuCheckbox && leftSidebar) {
-        menuCheckbox.addEventListener('change', function () {
-            leftSidebar.classList.toggle('collapsed', !this.checked);
-        });
+        menuCheckbox.addEventListener('change', syncMenu);
     }
 });


### PR DESCRIPTION
## Summary
- Collapse sidebar by default when viewport is 768px wide or less
- Sync `MenuLateralExpandido` checkbox with sidebar state on resize

## Testing
- `npm test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b501a95cc8832c9b360cabee4ad86b