### PR TITLE
Enable form login and add reset token migration

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
@@ -34,7 +34,7 @@ public class AccountController : Controller
     }
 
     [HttpPost]
-    public async Task<IActionResult> Login([FromBody] LoginViewModel model)
+    public async Task<IActionResult> Login([FromForm] LoginViewModel model)
     {
         if (!ModelState.IsValid)
         {

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
@@ -11,8 +11,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Sistema</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" href="~/dist/site.css" asp-append-version="true" />
-    <link rel="stylesheet" href="~/dist/login.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/login.css" asp-append-version="true" />
 </head>
 <body>
     <div class="container-fluid login-container">
@@ -49,8 +49,8 @@
 
     <div id="loadingModal"></div>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
-    <script src="~/dist/site.js" asp-append-version="true"></script>
-    <script src="~/dist/login.js" asp-append-version="true"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/login.js" asp-append-version="true"></script>
     @await Html.PartialAsync("_ValidationScriptsPartial")
     <div id="registerModal" style="display:none">
         @await Html.PartialAsync("_RegisterPartial", new Sistema.MVC.Models.RegisterViewModel())

--- a/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901143437_AddResetTokenFields.Designer.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901143437_AddResetTokenFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sistema.INFRA.Data;
 
@@ -11,9 +12,11 @@ using Sistema.INFRA.Data;
 namespace Sistema.INFRA.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250901143437_AddResetTokenFields")]
+    partial class AddResetTokenFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901143437_AddResetTokenFields.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Migrations/20250901143437_AddResetTokenFields.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sistema.INFRA.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResetTokenFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ResetToken",
+                table: "Usuario",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ResetTokenExpiration",
+                table: "Usuario",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ResetToken",
+                table: "Usuario");
+
+            migrationBuilder.DropColumn(
+                name: "ResetTokenExpiration",
+                table: "Usuario");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Accept form submissions in `AccountController` login action
- Update login view to load scripts and styles from `/js` and `/css`
- Add EF migration creating `ResetToken` and `ResetTokenExpiration` columns

## Testing
- `npm run build`
- `dotnet build`
- `dotnet ef database update` *(fails: Could not connect to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac3c1ef4832ca2b249f917f2b6ab