### PR TITLE
style: ajustar componentes ao tema escuro

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
@@ -48,7 +48,6 @@ body {
 
 header.navbar,
 footer.footer {
-  position: relative;
   z-index: 1001;
 }
 
@@ -145,4 +144,31 @@ body.bg-dark .card {
 body.bg-dark .card .form-label,
 body.bg-dark .card .card-title {
   color: #f8f9fa;
+}
+
+body.bg-dark .form-control,
+body.bg-dark .form-select {
+  background-color: #2c2f33;
+  color: #f8f9fa;
+  border-color: #495057;
+}
+
+body.bg-dark .form-control::placeholder {
+  color: #adb5bd;
+}
+
+body.bg-dark .table {
+  color: #f8f9fa;
+}
+
+body.bg-dark .table thead th {
+  background-color: #2c2f33;
+}
+
+body.bg-dark .table tbody tr {
+  background-color: #343a40;
+}
+
+body.bg-dark .table tbody tr:nth-of-type(odd) {
+  background-color: #2c2f33;
 }

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -58,7 +58,6 @@ body {
 
 header.navbar,
 footer.footer {
-  position: relative;
   z-index: 1001;
 }
 
@@ -116,6 +115,31 @@ footer.footer {
   display: inline;
 }
 
+@media (max-width: 768px) {
+  .sidebar {
+    width: 60px;
+  }
+  .sidebar .nav-link span {
+    display: none;
+  }
+  .sidebar .nav-link {
+    text-align: center;
+  }
+  .sidebar .nav-link i {
+    margin-right: 0;
+  }
+  .sidebar:hover {
+    width: 200px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+  }
+  .sidebar:hover .nav-link span {
+    display: inline;
+  }
+}
 body.bg-dark .card {
   background-color: #2c2f33;
   color: #f8f9fa;
@@ -126,6 +150,33 @@ body.bg-dark .card .card-title {
   color: #f8f9fa;
 }
 
+body.bg-dark .form-control,
+body.bg-dark .form-select {
+  background-color: #2c2f33;
+  color: #f8f9fa;
+  border-color: #495057;
+}
+
+body.bg-dark .form-control::placeholder {
+  color: #adb5bd;
+}
+
+body.bg-dark .table {
+  color: #f8f9fa;
+}
+
+body.bg-dark .table thead th {
+  background-color: #2c2f33;
+}
+
+body.bg-dark .table tbody tr {
+  background-color: #343a40;
+}
+
+body.bg-dark .table tbody tr:nth-of-type(odd) {
+  background-color: #2c2f33;
+}
+
 :root {
   --header-bg: #0d6efd;
   --sidebar-bg: #0d6efd;
@@ -133,6 +184,14 @@ body.bg-dark .card .card-title {
   --footer-bg: #0d6efd;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --header-bg: #212529;
+    --sidebar-bg: #212529;
+    --rightbar-bg: #343a40;
+    --footer-bg: #212529;
+  }
+}
 .header-bg {
   background-color: var(--header-bg) !important;
 }
@@ -148,3 +207,5 @@ body.bg-dark .card .card-title {
 .footer-bg {
   background-color: var(--footer-bg) !important;
 }
+
+/*# sourceMappingURL=site.css.map */

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/dist/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/dist/site.css
@@ -58,7 +58,6 @@ body {
 
 header.navbar,
 footer.footer {
-  position: relative;
   z-index: 1001;
 }
 
@@ -116,6 +115,31 @@ footer.footer {
   display: inline;
 }
 
+@media (max-width: 768px) {
+  .sidebar {
+    width: 60px;
+  }
+  .sidebar .nav-link span {
+    display: none;
+  }
+  .sidebar .nav-link {
+    text-align: center;
+  }
+  .sidebar .nav-link i {
+    margin-right: 0;
+  }
+  .sidebar:hover {
+    width: 200px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+  }
+  .sidebar:hover .nav-link span {
+    display: inline;
+  }
+}
 body.bg-dark .card {
   background-color: #2c2f33;
   color: #f8f9fa;
@@ -126,6 +150,33 @@ body.bg-dark .card .card-title {
   color: #f8f9fa;
 }
 
+body.bg-dark .form-control,
+body.bg-dark .form-select {
+  background-color: #2c2f33;
+  color: #f8f9fa;
+  border-color: #495057;
+}
+
+body.bg-dark .form-control::placeholder {
+  color: #adb5bd;
+}
+
+body.bg-dark .table {
+  color: #f8f9fa;
+}
+
+body.bg-dark .table thead th {
+  background-color: #2c2f33;
+}
+
+body.bg-dark .table tbody tr {
+  background-color: #343a40;
+}
+
+body.bg-dark .table tbody tr:nth-of-type(odd) {
+  background-color: #2c2f33;
+}
+
 :root {
   --header-bg: #0d6efd;
   --sidebar-bg: #0d6efd;
@@ -133,6 +184,14 @@ body.bg-dark .card .card-title {
   --footer-bg: #0d6efd;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --header-bg: #212529;
+    --sidebar-bg: #212529;
+    --rightbar-bg: #343a40;
+    --footer-bg: #212529;
+  }
+}
 .header-bg {
   background-color: var(--header-bg) !important;
 }
@@ -148,3 +207,5 @@ body.bg-dark .card .card-title {
 .footer-bg {
   background-color: var(--footer-bg) !important;
 }
+
+/*# sourceMappingURL=site.css.map */


### PR DESCRIPTION
## Summary
- harmonizar campos de formulário com o modo escuro
- alinhar cabeçalhos e linhas de tabelas ao tema
- impedir que estilos de header e footer anulem classes fixas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3f71548832c92c05cd5f455b2ad