### PR TITLE
Padroniza layout, temas e navegação

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Models/PageHeaderViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/PageHeaderViewModel.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sistema.MVC.Models;
+
+public class PageHeaderViewModel
+{
+    [Required]
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+}

--- a/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Account/Login.cshtml
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/login.css" asp-append-version="true" />
 </head>
-<body>
+<body data-bs-theme="light">
     <div class="container-fluid login-container">
         <div class="row min-vh-100">
             <div class="col-md-6 login-left d-flex flex-column justify-content-center align-items-center text-center p-5">
@@ -26,14 +26,14 @@
                     <h2 class="mb-4 text-center">@ViewData["Title"]</h2>
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <form asp-action="Login" method="post" id="loginForm">
-                        <div class="mb-3">
-                            <label asp-for="Cpf" class="form-label"></label>
-                            <input asp-for="Cpf" class="form-control" placeholder="CPF" autocomplete="username" aria-label="CPF" />
+                        <div class="form-floating mb-3">
+                            <input asp-for="Cpf" class="form-control" autocomplete="username" aria-label="CPF" placeholder="CPF" />
+                            <label asp-for="Cpf"></label>
                             <span asp-validation-for="Cpf" class="text-danger"></span>
                         </div>
-                        <div class="mb-3">
-                            <label asp-for="Senha" class="form-label"></label>
-                            <input asp-for="Senha" class="form-control" type="password" placeholder="Senha" autocomplete="current-password" aria-label="Senha" />
+                        <div class="form-floating mb-3">
+                            <input asp-for="Senha" class="form-control" type="password" autocomplete="current-password" aria-label="Senha" placeholder="Senha" />
+                            <label asp-for="Senha"></label>
                             <span asp-validation-for="Senha" class="text-danger"></span>
                         </div>
                         <button type="submit" class="btn btn-primary w-100">Entrar</button>

--- a/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Create.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Create.cshtml
@@ -2,40 +2,48 @@
 @{
     ViewData["Title"] = "Nova Configuração";
 }
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Configurações",
+    Description = "Gerencie as configurações do sistema."
+})
+
 <div class="card">
+    <form asp-action="Create" method="post">
     <div class="card-body">
-        <h2 class="card-title">@ViewData["Title"]</h2>
-        <form asp-action="Create" method="post">
-    <div class="mb-3">
-        <label asp-for="Agrupamento" class="form-label"></label>
-        <input asp-for="Agrupamento" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Agrupamento" class="form-control" placeholder="Agrupamento" />
+        <label asp-for="Agrupamento"></label>
         <span asp-validation-for="Agrupamento" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Chave" class="form-label"></label>
-        <input asp-for="Chave" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Chave" class="form-control" placeholder="Chave" />
+        <label asp-for="Chave"></label>
         <span asp-validation-for="Chave" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Valor" class="form-label"></label>
-        <input asp-for="Valor" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Valor" class="form-control" placeholder="Valor" />
+        <label asp-for="Valor"></label>
     </div>
-    <div class="mb-3">
-        <label asp-for="Tipo" class="form-label"></label>
+    <div class="form-floating mb-3">
         <select asp-for="Tipo" class="form-select" asp-items="Html.GetEnumSelectList<ConfiguracaoTipo>()"></select>
+        <label asp-for="Tipo"></label>
     </div>
-    <div class="mb-3">
-        <label asp-for="Descricao" class="form-label"></label>
-        <input asp-for="Descricao" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Descricao" class="form-control" placeholder="Descrição" />
+        <label asp-for="Descricao"></label>
     </div>
-    <div class="mb-3 form-check">
+    <div class="form-check mb-3">
         <input asp-for="Ativo" class="form-check-input" />
         <label asp-for="Ativo" class="form-check-label"></label>
     </div>
-    <button type="submit" class="btn btn-primary">Salvar</button>
-    <a asp-action="Index" asp-route-agrupamento="@Model.Agrupamento" class="btn btn-secondary">Cancelar</a>
-        </form>
     </div>
+    <div class="card-footer text-end">
+        <button type="submit" class="btn btn-primary">Salvar</button>
+        <a asp-action="Index" asp-route-agrupamento="@Model.Agrupamento" class="btn btn-secondary">Cancelar</a>
+    </div>
+    </form>
 </div>
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Edit.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Edit.cshtml
@@ -2,41 +2,49 @@
 @{
     ViewData["Title"] = "Editar Configuração";
 }
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Configurações",
+    Description = "Atualize as configurações do sistema."
+})
+
 <div class="card">
-    <div class="card-body">
-        <h2 class="card-title">@ViewData["Title"]</h2>
-        <form asp-action="Edit" method="post">
+    <form asp-action="Edit" method="post">
     <input type="hidden" asp-for="Id" />
-    <div class="mb-3">
-        <label asp-for="Agrupamento" class="form-label"></label>
-        <input asp-for="Agrupamento" class="form-control" />
+    <div class="card-body">
+    <div class="form-floating mb-3">
+        <input asp-for="Agrupamento" class="form-control" placeholder="Agrupamento" />
+        <label asp-for="Agrupamento"></label>
         <span asp-validation-for="Agrupamento" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Chave" class="form-label"></label>
-        <input asp-for="Chave" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Chave" class="form-control" placeholder="Chave" />
+        <label asp-for="Chave"></label>
         <span asp-validation-for="Chave" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Valor" class="form-label"></label>
-        <input asp-for="Valor" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Valor" class="form-control" placeholder="Valor" />
+        <label asp-for="Valor"></label>
     </div>
-    <div class="mb-3">
-        <label asp-for="Tipo" class="form-label"></label>
+    <div class="form-floating mb-3">
         <select asp-for="Tipo" class="form-select" asp-items="Html.GetEnumSelectList<ConfiguracaoTipo>()"></select>
+        <label asp-for="Tipo"></label>
     </div>
-    <div class="mb-3">
-        <label asp-for="Descricao" class="form-label"></label>
-        <input asp-for="Descricao" class="form-control" />
+    <div class="form-floating mb-3">
+        <input asp-for="Descricao" class="form-control" placeholder="Descrição" />
+        <label asp-for="Descricao"></label>
     </div>
-    <div class="mb-3 form-check">
+    <div class="form-check mb-3">
         <input asp-for="Ativo" class="form-check-input" />
         <label asp-for="Ativo" class="form-check-label"></label>
     </div>
-    <button type="submit" class="btn btn-primary">Salvar</button>
-    <a asp-action="Index" asp-route-agrupamento="@Model.Agrupamento" class="btn btn-secondary">Cancelar</a>
-        </form>
     </div>
+    <div class="card-footer text-end">
+        <button type="submit" class="btn btn-primary">Salvar</button>
+        <a asp-action="Index" asp-route-agrupamento="@Model.Agrupamento" class="btn btn-secondary">Cancelar</a>
+    </div>
+    </form>
 </div>
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Configuracao/Index.cshtml
@@ -2,22 +2,24 @@
 @{
     ViewData["Title"] = "Configurações";
 }
-<h2>Configurações - @Model.Agrupamento</h2>
-<div class="card mb-3">
-    <div class="card-body">
-        <form method="get" class="row g-3 mb-3">
-            <div class="col-auto">
-                <input type="text" name="agrupamento" value="@Model.Agrupamento" class="form-control" placeholder="Agrupamento" />
-            </div>
-            <div class="col-auto">
-                <button type="submit" class="btn btn-secondary">Buscar</button>
-            </div>
-            <div class="col-auto">
-                <a class="btn btn-primary" asp-action="Create" asp-route-agrupamento="@Model.Agrupamento">Nova Configuração</a>
-            </div>
-        </form>
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Configurações",
+    Description = "Gerencie as configurações do sistema."
+})
+
+<form method="get" class="mb-3">
+    <div class="card">
+        <div class="card-body">
+            <input type="text" name="agrupamento" value="@Model.Agrupamento" class="form-control" placeholder="Agrupamento" />
+        </div>
+        <div class="card-footer text-end">
+            <button type="submit" class="btn btn-secondary">Buscar</button>
+            <a class="btn btn-primary" asp-action="Create" asp-route-agrupamento="@Model.Agrupamento">Nova Configuração</a>
+        </div>
     </div>
-</div>
+</form>
 <div class="card">
     <div class="card-body">
         <table class="table mb-0">

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
@@ -2,12 +2,24 @@
 @{
     ViewData["Title"] = Model.Assunto;
 }
-<h2>@Model.Assunto</h2>
-<div>
-    <strong>De:</strong> @Model.RemetenteNome<br />
-    <strong>Para:</strong> @Model.DestinatarioNome<br />
-    <strong>Data:</strong> @Model.DataInclusao.ToLocalTime().ToString("g")
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = Model.Assunto,
+    Description = "Detalhes da mensagem."
+})
+
+<div class="card">
+    <div class="card-body">
+        <div>
+            <strong>De:</strong> @Model.RemetenteNome<br />
+            <strong>Para:</strong> @Model.DestinatarioNome<br />
+            <strong>Data:</strong> @Model.DataInclusao.ToLocalTime().ToString("g")
+        </div>
+        <hr />
+        <div>@Model.Corpo</div>
+    </div>
+    <div class="card-footer text-end">
+        <a href="@Url.Action("Nova", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })" class="btn btn-secondary">Responder</a>
+    </div>
 </div>
-<hr />
-<div>@Model.Corpo</div>
-<a href="@Url.Action("Nova", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })" class="btn btn-secondary mt-3">Responder</a>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
@@ -2,30 +2,48 @@
 @{
     ViewData["Title"] = "Caixa de Entrada";
 }
-<h2>Mensagens</h2>
-<form method="get">
-    <input type="text" name="palavraChave" placeholder="Buscar" value="@Model.PalavraChave" />
-    <button type="submit">Buscar</button>
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Mensagens",
+    Description = "Visualize e gerencie suas mensagens."
+})
+
+<form method="get" class="mb-3">
+    <div class="card">
+        <div class="card-body">
+            <input type="text" name="palavraChave" class="form-control" placeholder="Buscar" value="@Model.PalavraChave" />
+        </div>
+        <div class="card-footer text-end">
+            <button type="submit" class="btn btn-secondary">Buscar</button>
+        </div>
+    </div>
 </form>
-<table class="table">
-    <thead>
-        <tr>
-            <th>Assunto</th>
-            <th>Remetente</th>
-            <th>Data</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var m in Model.Mensagens)
-    {
-        <tr class="@(m.Lida ? "" : "fw-bold")">
-            <td>@m.Assunto</td>
-            <td>@m.RemetenteNome</td>
-            <td>@m.DataInclusao.ToLocalTime().ToString("g")</td>
-            <td><a href="@Url.Action("Detalhe", new { id = m.Id })">Abrir</a></td>
-        </tr>
-    }
-    </tbody>
-</table>
-<a href="@Url.Action("Nova")" class="btn btn-primary">Nova mensagem</a>
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table mb-0">
+            <thead>
+                <tr>
+                    <th>Assunto</th>
+                    <th>Remetente</th>
+                    <th>Data</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var m in Model.Mensagens)
+            {
+                <tr class="@(m.Lida ? "" : "fw-bold")">
+                    <td>@m.Assunto</td>
+                    <td>@m.RemetenteNome</td>
+                    <td>@m.DataInclusao.ToLocalTime().ToString("g")</td>
+                    <td><a href="@Url.Action("Detalhe", new { id = m.Id })">Abrir</a></td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer text-end">
+        <a href="@Url.Action("Nova")" class="btn btn-primary">Nova mensagem</a>
+    </div>
+</div>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
@@ -3,20 +3,32 @@
     var destinatarioId = ViewBag.DestinatarioId as int?;
     var mensagemPaiId = ViewBag.MensagemPaiId as int?;
 }
-<h2>Nova mensagem</h2>
-<form method="post">
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Mensagens",
+    Description = "Envie uma nova mensagem."
+})
+
+<div class="card">
+    <form method="post">
     <input type="hidden" name="mensagemPaiId" value="@mensagemPaiId" />
-    <div class="mb-3">
-        <label>Destinatário</label>
-        <input type="number" name="destinatarioId" class="form-control" value="@destinatarioId" required />
+    <div class="card-body">
+        <div class="mb-3">
+            <label>Destinatário</label>
+            <input type="number" name="destinatarioId" class="form-control" value="@destinatarioId" required />
+        </div>
+        <div class="mb-3">
+            <label>Assunto</label>
+            <input type="text" name="assunto" class="form-control" required />
+        </div>
+        <div class="mb-3">
+            <label>Corpo</label>
+            <textarea name="corpo" class="form-control" rows="5"></textarea>
+        </div>
     </div>
-    <div class="mb-3">
-        <label>Assunto</label>
-        <input type="text" name="assunto" class="form-control" required />
+    <div class="card-footer text-end">
+        <button type="submit" class="btn btn-primary">Enviar</button>
     </div>
-    <div class="mb-3">
-        <label>Corpo</label>
-        <textarea name="corpo" class="form-control" rows="5"></textarea>
-    </div>
-    <button type="submit" class="btn btn-primary">Enviar</button>
-</form>
+    </form>
+</div>

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -13,8 +13,6 @@
     bool headerFixo = tema?.HeaderFixo ?? false;
     bool footerFixo = tema?.FooterFixo ?? false;
     bool menuExpandido = tema?.MenuLateralExpandido ?? true;
-    string bodyClass = modoEscuro ? "bg-dark text-white" : "bg-light text-dark";
-
     string GetTextClass(string hex)
     {
         if (string.IsNullOrWhiteSpace(hex)) return "text-dark";
@@ -35,7 +33,6 @@
     string rightText = GetTextClass(rightColor);
     string footerText = GetTextClass(footerColor);
     string headerNavbarClass = headerText == "text-white" ? "navbar-dark" : "navbar-light";
-    string sidebarCollapsedClass = menuExpandido ? string.Empty : "collapsed";
     string headerFixedClass = headerFixo ? "fixed-top" : string.Empty;
     string footerFixedClass = footerFixo ? "fixed-bottom" : string.Empty;
 }
@@ -48,12 +45,12 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
-<body class="@bodyClass @(headerFixo ? "pt-5" : string.Empty)">
+<body data-bs-theme="@(modoEscuro ? "dark" : "light")" class="@(headerFixo ? "pt-5" : string.Empty)">
     <a class="visually-hidden-focusable" href="#main">Pular para conteúdo</a>
     <div class="d-flex flex-column min-vh-100">
         <header class="navbar @headerNavbarClass @headerFixedClass header-bg">
             <div class="container-fluid">
-                <button class="btn btn-link @headerText" type="button" id="menuToggle"><i class="bi bi-list"></i></button>
+                <button class="btn btn-link @headerText" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarOffcanvas"><i class="bi bi-list"></i></button>
                 <a class="navbar-brand @headerText" asp-controller="Home" asp-action="Index">Sistema.MVC</a>
                 <div class="ms-auto d-flex align-items-center">
                     <button class="btn btn-link @headerText" type="button" id="temaToggle"><i class="bi bi-palette"></i></button>
@@ -71,30 +68,6 @@
             </div>
         </header>
         <div class="flex-grow-1 d-flex">
-            <aside class="sidebar @sidebarCollapsedClass sidebar-bg">
-                <nav aria-label="Menu principal">
-                    <ul class="nav flex-column">
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Home" asp-action="Index"><i class="bi bi-house me-2"></i><span>Home</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Home" asp-action="Privacy"><i class="bi bi-shield-lock me-2"></i><span>Privacy</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Tema" asp-action="Edit"><i class="bi bi-palette me-2"></i><span>Tema</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Configuracao" asp-action="Index"><i class="bi bi-gear me-2"></i><span>Configurações</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Mensagem" asp-action="Index"><i class="bi bi-envelope me-2"></i><span>Mensagens</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @leftText" asp-controller="Documentacao" asp-action="Index"><i class="bi bi-book me-2"></i><span>Documentação</span></a>
-                        </li>
-                    </ul>
-                </nav>
-            </aside>
             <div class="content flex-grow-1 p-3">
                 <main id="main" role="main" class="pb-3">
                     @RenderBody()
@@ -163,6 +136,32 @@
             <button type="submit" class="btn btn-primary">Salvar</button>
         </form>
     </aside>
+    <div class="offcanvas offcanvas-start sidebar-bg" tabindex="-1" id="sidebarOffcanvas">
+        <div class="offcanvas-body">
+            <nav aria-label="Menu principal">
+                <ul class="nav flex-column">
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Home" asp-action="Index"><i class="bi bi-house me-2"></i><span>Home</span></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Home" asp-action="Privacy"><i class="bi bi-shield-lock me-2"></i><span>Privacy</span></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Tema" asp-action="Edit"><i class="bi bi-palette me-2"></i><span>Tema</span></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Configuracao" asp-action="Index"><i class="bi bi-gear me-2"></i><span>Configurações</span></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Mensagem" asp-action="Index"><i class="bi bi-envelope me-2"></i><span>Mensagens</span></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText" asp-controller="Documentacao" asp-action="Index"><i class="bi bi-book me-2"></i><span>Documentação</span></a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_PageHeader.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_PageHeader.cshtml
@@ -1,0 +1,6 @@
+@model Sistema.MVC.Models.PageHeaderViewModel
+<h2>@Model.Title</h2>
+@if (!string.IsNullOrEmpty(Model.Description))
+{
+    <p class="text-muted small">@Model.Description</p>
+}

--- a/0 - Apresentacao/Sistema.MVC/Views/Tema/Edit.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Tema/Edit.cshtml
@@ -2,10 +2,16 @@
 @{
     ViewData["Title"] = "Tema";
 }
+
+@await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
+{
+    Title = "Tema",
+    Description = "Personalize o sistema com suas preferências."
+})
+
 <div class="card">
+    <form asp-action="Edit" method="post">
     <div class="card-body">
-        <h2 class="card-title">Preferências de Tema</h2>
-        <form asp-action="Edit" method="post">
     <div class="mb-3">
         <label class="form-label">Modo</label>
         <div class="form-check">
@@ -17,21 +23,21 @@
             <label class="form-check-label">Escuro</label>
         </div>
     </div>
-    <div class="mb-3">
-        <label class="form-label" for="CorHeader">Cor do Header</label>
-        <input type="color" class="form-control form-control-color" asp-for="CorHeader" />
+    <div class="form-floating mb-3">
+        <input type="color" class="form-control form-control-color" asp-for="CorHeader" placeholder="Cor do Header" />
+        <label asp-for="CorHeader"></label>
     </div>
-    <div class="mb-3">
-        <label class="form-label" for="CorBarraEsquerda">Barra Lateral Esquerda</label>
-        <input type="color" class="form-control form-control-color" asp-for="CorBarraEsquerda" />
+    <div class="form-floating mb-3">
+        <input type="color" class="form-control form-control-color" asp-for="CorBarraEsquerda" placeholder="Barra Lateral Esquerda" />
+        <label asp-for="CorBarraEsquerda"></label>
     </div>
-    <div class="mb-3">
-        <label class="form-label" for="CorBarraDireita">Barra Lateral Direita</label>
-        <input type="color" class="form-control form-control-color" asp-for="CorBarraDireita" />
+    <div class="form-floating mb-3">
+        <input type="color" class="form-control form-control-color" asp-for="CorBarraDireita" placeholder="Barra Lateral Direita" />
+        <label asp-for="CorBarraDireita"></label>
     </div>
-    <div class="mb-3">
-        <label class="form-label" for="CorFooter">Rodapé</label>
-        <input type="color" class="form-control form-control-color" asp-for="CorFooter" />
+    <div class="form-floating mb-3">
+        <input type="color" class="form-control form-control-color" asp-for="CorFooter" placeholder="Rodapé" />
+        <label asp-for="CorFooter"></label>
     </div>
     <div class="form-check form-switch mb-2">
         <input class="form-check-input" type="checkbox" asp-for="HeaderFixo" />
@@ -45,7 +51,9 @@
         <input class="form-check-input" type="checkbox" asp-for="MenuLateralExpandido" />
         <label class="form-check-label" asp-for="MenuLateralExpandido">Menu expandido</label>
     </div>
-    <button type="submit" class="btn btn-primary">Salvar</button>
-        </form>
     </div>
+    <div class="card-footer text-end">
+        <button type="submit" class="btn btn-primary">Salvar</button>
+    </div>
+    </form>
 </div>

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_base.scss
@@ -63,108 +63,14 @@ footer.footer {
   transform: translateX(0);
 }
 
-.sidebar {
-  width: 200px;
-  min-width: 60px;
-  flex-shrink: 0;
-  transition: width 0.3s ease;
-  overflow-x: hidden;
-  position: relative;
+.form-control,
+.form-select,
+.form-check-input {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
 }
 
-.sidebar.collapsed {
-  width: 60px;
-}
-
-.sidebar.collapsed .nav-link span {
-  display: none;
-}
-
-.sidebar.collapsed .nav-link {
-  text-align: center;
-}
-
-.sidebar.collapsed .nav-link i {
-  margin-right: 0;
-}
-
-.sidebar.collapsed:hover {
-  width: 200px;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1000;
-}
-
-.sidebar.collapsed:hover .nav-link span {
-  display: inline;
-}
-
-@media (max-width: 768px) {
-  .sidebar {
-    width: 60px;
-  }
-
-  .sidebar .nav-link span {
-    display: none;
-  }
-
-  .sidebar .nav-link {
-    text-align: center;
-  }
-
-  .sidebar .nav-link i {
-    margin-right: 0;
-  }
-
-  .sidebar:hover {
-    width: 200px;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1000;
-  }
-
-  .sidebar:hover .nav-link span {
-    display: inline;
-  }
-}
-
-body.bg-dark .card {
-  background-color: #2c2f33;
-  color: #f8f9fa;
-}
-
-body.bg-dark .card .form-label,
-body.bg-dark .card .card-title {
-  color: #f8f9fa;
-}
-
-body.bg-dark .form-control,
-body.bg-dark .form-select {
-  background-color: #2c2f33;
-  color: #f8f9fa;
-  border-color: #495057;
-}
-
-body.bg-dark .form-control::placeholder {
-  color: #adb5bd;
-}
-
-body.bg-dark .table {
-  color: #f8f9fa;
-}
-
-body.bg-dark .table thead th {
-  background-color: #2c2f33;
-}
-
-body.bg-dark .table tbody tr {
-  background-color: #343a40;
-}
-
-body.bg-dark .table tbody tr:nth-of-type(odd) {
-  background-color: #2c2f33;
+.form-check-input:checked {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -73,104 +73,16 @@ footer.footer {
   transform: translateX(0);
 }
 
-.sidebar {
-  width: 200px;
-  min-width: 60px;
-  flex-shrink: 0;
-  transition: width 0.3s ease;
-  overflow-x: hidden;
-  position: relative;
+.form-control,
+.form-select,
+.form-check-input {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
 }
 
-.sidebar.collapsed {
-  width: 60px;
-}
-
-.sidebar.collapsed .nav-link span {
-  display: none;
-}
-
-.sidebar.collapsed .nav-link {
-  text-align: center;
-}
-
-.sidebar.collapsed .nav-link i {
-  margin-right: 0;
-}
-
-.sidebar.collapsed:hover {
-  width: 200px;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1000;
-}
-
-.sidebar.collapsed:hover .nav-link span {
-  display: inline;
-}
-
-@media (max-width: 768px) {
-  .sidebar {
-    width: 60px;
-  }
-  .sidebar .nav-link span {
-    display: none;
-  }
-  .sidebar .nav-link {
-    text-align: center;
-  }
-  .sidebar .nav-link i {
-    margin-right: 0;
-  }
-  .sidebar:hover {
-    width: 200px;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1000;
-  }
-  .sidebar:hover .nav-link span {
-    display: inline;
-  }
-}
-body.bg-dark .card {
-  background-color: #2c2f33;
-  color: #f8f9fa;
-}
-
-body.bg-dark .card .form-label,
-body.bg-dark .card .card-title {
-  color: #f8f9fa;
-}
-
-body.bg-dark .form-control,
-body.bg-dark .form-select {
-  background-color: #2c2f33;
-  color: #f8f9fa;
-  border-color: #495057;
-}
-
-body.bg-dark .form-control::placeholder {
-  color: #adb5bd;
-}
-
-body.bg-dark .table {
-  color: #f8f9fa;
-}
-
-body.bg-dark .table thead th {
-  background-color: #2c2f33;
-}
-
-body.bg-dark .table tbody tr {
-  background-color: #343a40;
-}
-
-body.bg-dark .table tbody tr:nth-of-type(odd) {
-  background-color: #2c2f33;
+.form-check-input:checked {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 
 :root {

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -30,12 +30,9 @@ window.showInfo = function (message) {
 $(function () {
     var root = document.documentElement;
     var savedTheme = localStorage.getItem('theme');
-    var theme = savedTheme || (root.dataset.theme || ($('body').hasClass('bg-dark') ? 'dark' : 'light'));
-    root.dataset.theme = theme;
+    var theme = savedTheme || (document.body.getAttribute('data-bs-theme') || 'light');
+    document.body.setAttribute('data-bs-theme', theme);
     root.style.colorScheme = theme;
-    $('body')
-        .toggleClass('bg-dark text-white', theme === 'dark')
-        .toggleClass('bg-light text-dark', theme === 'light');
 
     var $temaToggle = $('#temaToggle');
     var $temaSidebar = $('#temaSidebar');
@@ -51,46 +48,13 @@ $(function () {
         });
     }
 
-    var $menuToggle = $('#menuToggle');
-    var $leftSidebar = $('aside.sidebar');
-    var $menuCheckbox = $('#MenuLateralExpandido');
-    var syncMenu = function () {
-        if (!$leftSidebar.length) return;
-        if (window.innerWidth <= 768) {
-            $leftSidebar.addClass('collapsed');
-            if ($menuCheckbox.length) {
-                $menuCheckbox.prop('checked', false);
-            }
-        } else if ($menuCheckbox.length) {
-            $leftSidebar.toggleClass('collapsed', !$menuCheckbox.prop('checked'));
-        } else {
-            $leftSidebar.removeClass('collapsed');
-        }
-    };
-
-    if ($menuToggle.length && $leftSidebar.length) {
-        $menuToggle.on('click', function () {
-            $leftSidebar.toggleClass('collapsed');
-            if ($menuCheckbox.length) {
-                $menuCheckbox.prop('checked', !$leftSidebar.hasClass('collapsed'));
-            }
-            syncMenu();
-        });
-    }
-
-    $(window).on('resize', syncMenu);
-    syncMenu();
-
     AOS.init();
 
     $('input[name="ModoEscuro"]').on('change', function () {
         var theme = $(this).val() === 'true' ? 'dark' : 'light';
-        root.dataset.theme = theme;
+        document.body.setAttribute('data-bs-theme', theme);
         root.style.colorScheme = theme;
         localStorage.setItem('theme', theme);
-        $('body')
-            .toggleClass('bg-dark text-white', theme === 'dark')
-            .toggleClass('bg-light text-dark', theme === 'light');
     });
 
     var $headerInput = $('#CorHeader');
@@ -140,7 +104,4 @@ $(function () {
         });
     }
 
-    if ($menuCheckbox.length && $leftSidebar.length) {
-        $menuCheckbox.on('change', syncMenu);
-    }
 });


### PR DESCRIPTION
## Summary
- adiciona modelo e partial de cabeçalho reutilizável
- migra seleção de tema para `data-bs-theme` e usa menu lateral com offcanvas do Bootstrap
- unifica formulários com `form-floating`, rodapés com botões e ajusta cores de campos

## Testing
- `npx sass "0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss" "0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css"`
- `npm run build`
- `dotnet build` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d61d4a04832cbe5b16717d72fe02