### PR TITLE
Ajusta comportamento responsivo do menu lateral

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -50,7 +50,7 @@
     <div class="d-flex flex-column min-vh-100">
         <header class="navbar @headerNavbarClass @headerFixedClass header-bg">
             <div class="container-fluid">
-                <button class="btn p-0 border-0 bg-transparent @headerText" type="button" id="sidebarToggle"><i class="bi bi-list @headerText"></i></button>
+                <button class="btn p-0 border-0 bg-transparent @headerText @(menuExpandido ? "d-md-none" : string.Empty)" type="button" id="sidebarToggle"><i class="bi bi-list @headerText"></i></button>
                 <a class="navbar-brand @headerText" asp-controller="Home" asp-action="Index">Sistema.MVC</a>
                 <div class="ms-auto d-flex align-items-center">
                     <button class="btn btn-link @headerText" type="button" id="temaToggle"><i class="bi bi-palette"></i></button>
@@ -68,7 +68,7 @@
             </div>
         </header>
         <div class="flex-grow-1 d-flex">
-            <nav id="sidebar" class="sidebar sidebar-bg @leftText @(menuExpandido ? string.Empty : "collapsed")">
+            <nav id="sidebar" data-expanded="@(menuExpandido.ToString().ToLower())" class="sidebar sidebar-bg @leftText @(menuExpandido ? string.Empty : "collapsed")">
                 <ul class="nav flex-column">
                     <li class="nav-item">
                         <a class="nav-link @leftText" asp-controller="Home" asp-action="Index"><i class="bi bi-house me-2"></i><span>Home</span></a>

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -108,43 +108,45 @@ footer.footer {
   background-color: var(--sidebar-bg) !important;
 }
 
-.sidebar {
-  width: 250px;
-  transition: width 0.3s ease;
-}
-
-.sidebar.collapsed {
-  width: 60px;
-}
-
-.sidebar .nav-link {
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
-}
-
-.sidebar .nav-link i {
-  margin-right: 0.5rem;
-}
-
-.sidebar.collapsed .nav-link {
-  justify-content: center;
-}
-
-.sidebar.collapsed .nav-link i {
-  margin-right: 0;
-}
-
-.sidebar.collapsed .nav-link span {
-  display: none;
-}
-
 .rightbar-bg {
   background-color: var(--rightbar-bg) !important;
 }
 
 .footer-bg {
   background-color: var(--footer-bg) !important;
+}
+
+.sidebar {
+  width: 250px;
+  transition: width 0.3s ease;
+  flex-shrink: 0;
+}
+.sidebar.collapsed {
+  width: 60px;
+}
+.sidebar.collapsed .nav-link {
+  justify-content: center;
+}
+.sidebar.collapsed .nav-link i {
+  margin-right: 0;
+}
+.sidebar.collapsed .nav-link span {
+  display: none;
+}
+.sidebar.expanded {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100%;
+  z-index: 1040;
+}
+.sidebar .nav-link {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+.sidebar .nav-link i {
+  margin-right: 0.5rem;
 }
 
 /*# sourceMappingURL=site.css.map */

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
@@ -24,13 +24,14 @@
 .footer-bg { background-color: var(--footer-bg) !important; }
 
 .sidebar {
-  width: 250px;
-  transition: width 0.3s ease;
+    width: 250px;
+    transition: width 0.3s ease;
+    flex-shrink: 0;
 
-  &.collapsed {
-    width: 60px;
+    &.collapsed {
+      width: 60px;
 
-    .nav-link {
+      .nav-link {
       justify-content: center;
 
       i {
@@ -41,12 +42,20 @@
         display: none;
       }
     }
-  }
+    }
 
-  .nav-link {
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
+    &.expanded {
+      position: fixed;
+      left: 0;
+      top: 0;
+      height: 100%;
+      z-index: 1040;
+    }
+
+    .nav-link {
+      display: flex;
+      align-items: center;
+      white-space: nowrap;
 
     i {
       margin-right: 0.5rem;

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -107,8 +107,29 @@ $(function () {
     var $sidebarToggle = $('#sidebarToggle');
     var $sidebar = $('#sidebar');
     if ($sidebarToggle.length && $sidebar.length) {
-        $sidebarToggle.on('click', function () {
-            $sidebar.toggleClass('collapsed');
+        var themeExpanded = $sidebar.data('expanded');
+
+        function applySidebarState() {
+            if ($(window).width() < 768) {
+                $sidebar.addClass('collapsed');
+            } else {
+                $sidebar.toggleClass('collapsed', !themeExpanded);
+            }
+        }
+
+        applySidebarState();
+        $(window).on('resize', applySidebarState);
+
+        $sidebarToggle.on('click', function (e) {
+            e.stopPropagation();
+            $sidebar.addClass('expanded').removeClass('collapsed');
+        });
+
+        $(document).on('click', function (e) {
+            if ($sidebar.hasClass('expanded') && !$sidebar.is(e.target) && $sidebar.has(e.target).length === 0 && !$sidebarToggle.is(e.target) && $sidebarToggle.has(e.target).length === 0) {
+                $sidebar.removeClass('expanded');
+                applySidebarState();
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- Exibe ícones ao recolher a barra lateral e permite expansão sobreposta à tela
- Mostra o botão hamburger apenas quando necessário e esconde ao clicar fora
- Colapsa automaticamente o menu em larguras abaixo de `md`

## Testing
- `npx sass "0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss" "0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e62b1a8c832cb1adc67651c88e8c