### PR TITLE
Move service XML docs to interfaces

### DIFF
--- a/2 - Dominio/Sistema.CORE/Services/AuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/AuthService.cs
@@ -10,22 +10,12 @@ using System.Text;
 
 namespace Sistema.CORE.Services;
 
-/// <summary>
-/// Serviço de autenticação responsável por validar credenciais e emitir tokens JWT.
-/// </summary>
 public class AuthService(IUnitOfWork uow, IPasswordHasher<Usuario> hasher, IConfiguration config) : IAuthService
 {
     private readonly IUnitOfWork _uow = uow;
     private readonly IPasswordHasher<Usuario> _hasher = hasher;
     private readonly IConfiguration _config = config;
 
-    /// <summary>
-    /// Autentica um usuário pelo CPF e senha, retornando um token JWT válido ou nulo em caso de falha.
-    /// </summary>
-    /// <param name="cpf">CPF informado no login.</param>
-    /// <param name="senha">Senha em texto puro para validação.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Token JWT quando autenticado ou nulo quando inválido.</returns>
     public async Task<string?> AutenticarAsync(string cpf, string senha, CancellationToken cancellationToken = default)
     {
         var usuario = await _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);

--- a/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/ConfiguracaoService.cs
@@ -7,38 +7,16 @@ using Sistema.CORE.Services.Interfaces;
 
 namespace Sistema.CORE.Services;
 
-/// <summary>
-/// Serviço responsável por gerenciar configurações do sistema e delegar persistência ao repositório.
-/// </summary>
 public class ConfiguracaoService(IUnitOfWork uow) : IConfiguracaoService
 {
     private readonly IUnitOfWork _uow = uow;
 
-    /// <summary>
-    /// Busca configurações pertencentes a um agrupamento específico.
-    /// </summary>
-    /// <param name="agrupamento">Agrupamento utilizado como chave de filtro.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Enumerable com as configurações encontradas.</returns>
     public Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default) =>
         _uow.Configuracoes.BuscarPorAgrupamentoAsync(agrupamento, cancellationToken);
 
-    /// <summary>
-    /// Obtém uma configuração específica a partir do agrupamento e da chave informados.
-    /// </summary>
-    /// <param name="agrupamento">Agrupamento ao qual a configuração pertence.</param>
-    /// <param name="chave">Chave exclusiva dentro do agrupamento.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Configuração localizada ou nula quando inexistente.</returns>
     public Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default) =>
         _uow.Configuracoes.BuscarPorChaveAsync(agrupamento, chave, cancellationToken);
 
-    /// <summary>
-    /// Adiciona uma nova configuração ao repositório e persiste a alteração.
-    /// </summary>
-    /// <param name="config">Entidade de configuração a ser incluída.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Entidade persistida com seu identificador.</returns>
     public async Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default)
     {
         var result = await _uow.Configuracoes.AdicionarAsync(config, cancellationToken);
@@ -46,22 +24,12 @@ public class ConfiguracaoService(IUnitOfWork uow) : IConfiguracaoService
         return result;
     }
 
-    /// <summary>
-    /// Atualiza uma configuração existente e confirma a transação.
-    /// </summary>
-    /// <param name="config">Configuração já existente com dados atualizados.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
     public async Task AtualizarAsync(Configuracao config, CancellationToken cancellationToken = default)
     {
         await _uow.Configuracoes.AtualizarAsync(config);
         await _uow.ConfirmarAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Remove uma configuração pelo identificador e persiste a exclusão.
-    /// </summary>
-    /// <param name="id">Identificador da configuração.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
     public async Task RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
         await _uow.Configuracoes.RemoverAsync(id, cancellationToken);

--- a/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/FuncionalidadeService.cs
@@ -7,38 +7,16 @@ using Sistema.CORE.Services.Interfaces;
 
 namespace Sistema.CORE.Services;
 
-/// <summary>
-/// Serviço que gerencia funcionalidades do sistema e registra auditorias das operações.
-/// </summary>
 public class FuncionalidadeService(IUnitOfWork uow, ILogService log) : IFuncionalidadeService
 {
     private readonly IUnitOfWork _uow = uow;
     private readonly ILogService _log = log;
 
-    /// <summary>
-    /// Obtém funcionalidades com suporte a paginação.
-    /// </summary>
-    /// <param name="page">Página solicitada (base 1).</param>
-    /// <param name="pageSize">Quantidade de registros por página.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado paginado de funcionalidades.</returns>
     public Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default)
         => _uow.Funcionalidades.BuscarPaginadasAsync(page, pageSize, cancellationToken);
 
-    /// <summary>
-    /// Busca uma funcionalidade pelo identificador.
-    /// </summary>
-    /// <param name="id">Identificador da funcionalidade.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Funcionalidade encontrada ou nula.</returns>
     public Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Funcionalidades.BuscarPorIdAsync(id, cancellationToken);
 
-    /// <summary>
-    /// Adiciona uma nova funcionalidade e registra o evento no log.
-    /// </summary>
-    /// <param name="func">Entidade a ser criada.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado com a entidade criada.</returns>
     public async Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
         await _uow.Funcionalidades.AdicionarAsync(func, cancellationToken);
@@ -47,12 +25,6 @@ public class FuncionalidadeService(IUnitOfWork uow, ILogService log) : IFunciona
         return new OperationResult<Funcionalidade>(true, "Criado", func);
     }
 
-    /// <summary>
-    /// Atualiza uma funcionalidade existente e registra a operação.
-    /// </summary>
-    /// <param name="func">Funcionalidade com dados atualizados.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado da operação.</returns>
     public async Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default)
     {
         await _uow.Funcionalidades.AtualizarAsync(func);
@@ -61,12 +33,6 @@ public class FuncionalidadeService(IUnitOfWork uow, ILogService log) : IFunciona
         return new OperationResult(true, "Atualizado");
     }
 
-    /// <summary>
-    /// Remove uma funcionalidade e registra o evento de exclusão.
-    /// </summary>
-    /// <param name="id">Identificador da funcionalidade.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado da operação.</returns>
     public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
         await _uow.Funcionalidades.RemoverAsync(id, cancellationToken);

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IAuthService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IAuthService.cs
@@ -1,6 +1,16 @@
 namespace Sistema.CORE.Services.Interfaces;
 
+/// <summary>
+/// Serviço de autenticação responsável por validar credenciais e emitir tokens JWT.
+/// </summary>
 public interface IAuthService
 {
+    /// <summary>
+    /// Autentica um usuário pelo CPF e senha, retornando um token JWT válido ou nulo em caso de falha.
+    /// </summary>
+    /// <param name="cpf">CPF informado no login.</param>
+    /// <param name="senha">Senha em texto puro para validação.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Token JWT quando autenticado ou nulo quando inválido.</returns>
     Task<string?> AutenticarAsync(string cpf, string senha, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IConfiguracaoService.cs
@@ -2,11 +2,47 @@ using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Services.Interfaces;
 
+/// <summary>
+/// Serviço responsável por gerenciar configurações do sistema e delegar persistência ao repositório.
+/// </summary>
 public interface IConfiguracaoService
 {
+    /// <summary>
+    /// Busca configurações pertencentes a um agrupamento específico.
+    /// </summary>
+    /// <param name="agrupamento">Agrupamento utilizado como chave de filtro.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Enumerable com as configurações encontradas.</returns>
     Task<IEnumerable<Configuracao>> BuscarPorAgrupamentoAsync(string agrupamento, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma configuração específica a partir do agrupamento e da chave informados.
+    /// </summary>
+    /// <param name="agrupamento">Agrupamento ao qual a configuração pertence.</param>
+    /// <param name="chave">Chave exclusiva dentro do agrupamento.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Configuração localizada ou nula quando inexistente.</returns>
     Task<Configuracao?> BuscarPorChaveAsync(string agrupamento, string chave, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adiciona uma nova configuração ao repositório e persiste a alteração.
+    /// </summary>
+    /// <param name="config">Entidade de configuração a ser incluída.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Entidade persistida com seu identificador.</returns>
     Task<Configuracao> AdicionarAsync(Configuracao config, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atualiza uma configuração existente e confirma a transação.
+    /// </summary>
+    /// <param name="config">Configuração já existente com dados atualizados.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
     Task AtualizarAsync(Configuracao config, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove uma configuração pelo identificador e persiste a exclusão.
+    /// </summary>
+    /// <param name="id">Identificador da configuração.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
     Task RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IFuncionalidadeService.cs
@@ -5,12 +5,49 @@ using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Services.Interfaces;
 
+/// <summary>
+/// Serviço que gerencia funcionalidades do sistema e registra auditorias das operações.
+/// </summary>
 public interface IFuncionalidadeService
 {
+    /// <summary>
+    /// Obtém funcionalidades com suporte a paginação.
+    /// </summary>
+    /// <param name="page">Página solicitada (base 1).</param>
+    /// <param name="pageSize">Quantidade de registros por página.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado paginado de funcionalidades.</returns>
     Task<PagedResult<Funcionalidade>> BuscarPaginadasAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Busca uma funcionalidade pelo identificador.
+    /// </summary>
+    /// <param name="id">Identificador da funcionalidade.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Funcionalidade encontrada ou nula.</returns>
     Task<Funcionalidade?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Adiciona uma nova funcionalidade e registra o evento no log.
+    /// </summary>
+    /// <param name="func">Entidade a ser criada.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado com a entidade criada.</returns>
     Task<OperationResult<Funcionalidade>> AdicionarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atualiza uma funcionalidade existente e registra a operação.
+    /// </summary>
+    /// <param name="func">Funcionalidade com dados atualizados.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado da operação.</returns>
     Task<OperationResult> AtualizarAsync(Funcionalidade func, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove uma funcionalidade e registra o evento de exclusão.
+    /// </summary>
+    /// <param name="id">Identificador da funcionalidade.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado da operação.</returns>
     Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IMensagemService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Sistema.CORE.Common;
@@ -6,15 +7,91 @@ using Sistema.CORE.Entities;
 
 namespace Sistema.CORE.Services.Interfaces
 {
+    /// <summary>
+    /// Serviço de mensagens responsável por consultas, envio e atualização de status de leitura.
+    /// </summary>
     public interface IMensagemService
     {
+        /// <summary>
+        /// Busca mensagens recebidas pelo usuário aplicando filtros opcionais e paginação.
+        /// </summary>
+        /// <param name="usuarioId">Identificador do destinatário.</param>
+        /// <param name="page">Página solicitada (base 1).</param>
+        /// <param name="pageSize">Quantidade de itens por página.</param>
+        /// <param name="remetenteId">Filtro opcional pelo remetente.</param>
+        /// <param name="palavraChave">Termo opcional pesquisado em assunto ou corpo.</param>
+        /// <param name="inicio">Data inicial do período desejado.</param>
+        /// <param name="fim">Data final do período desejado.</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>Resultado paginado com as mensagens encontradas.</returns>
         Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Busca mensagens enviadas por um usuário aplicando paginação padrão.
+        /// </summary>
+        /// <param name="usuarioId">Identificador do remetente.</param>
+        /// <param name="page">Página solicitada (base 1).</param>
+        /// <param name="pageSize">Quantidade máxima de itens por página.</param>
+        /// <param name="cancellationToken">Token de cancelamento da operação assíncrona.</param>
+        /// <returns>Lista paginada das mensagens enviadas.</returns>
         Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Obtém uma mensagem específica incluindo dados de remetente, destinatário e mensagem pai.
+        /// </summary>
+        /// <param name="id">Identificador único da mensagem.</param>
+        /// <param name="cancellationToken">Token de cancelamento da operação assíncrona.</param>
+        /// <returns>Instância encontrada ou nula quando inexistente.</returns>
         Task<Mensagem?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Recupera toda a conversa relacionada a uma mensagem desde a origem, validando a participação do usuário.
+        /// </summary>
+        /// <param name="mensagemId">Mensagem base da consulta.</param>
+        /// <param name="usuarioId">Usuário que solicita a conversa (precisa ser participante).</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>A mensagem raiz com suas respostas encadeadas ou nulo caso o usuário não tenha acesso.</returns>
         Task<Mensagem?> BuscarConversaAsync(int mensagemId, int usuarioId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Envia uma nova mensagem para um destinatário validando conteúdo e existência dos usuários envolvidos.
+        /// </summary>
+        /// <param name="remetenteId">Identificador opcional do remetente.</param>
+        /// <param name="destinatarioId">Identificador do destinatário obrigatório.</param>
+        /// <param name="assunto">Assunto a ser enviado.</param>
+        /// <param name="corpo">Corpo do texto da mensagem.</param>
+        /// <param name="mensagemPaiId">Identificador opcional da mensagem respondida.</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>Resultado contendo sucesso e o id da nova mensagem.</returns>
         Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Envia uma mensagem para todos os usuários de um perfil, retornando a lista de ids criados.
+        /// </summary>
+        /// <param name="remetenteId">Identificador opcional do remetente.</param>
+        /// <param name="perfilId">Perfil dos destinatários.</param>
+        /// <param name="assunto">Assunto compartilhado.</param>
+        /// <param name="corpo">Corpo compartilhado.</param>
+        /// <param name="mensagemPaiId">Mensagem à qual esta comunicação responde, quando aplicável.</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>Resultado com os ids das mensagens criadas ou erro contextualizado.</returns>
         Task<OperationResult<List<int>>> EnviarParaPerfilAsync(int? remetenteId, int perfilId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Marca uma mensagem como lida pelo destinatário, registrando a data de leitura.
+        /// </summary>
+        /// <param name="id">Identificador da mensagem.</param>
+        /// <param name="usuarioId">Usuário que está realizando a leitura.</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>Resultado indicando sucesso ou erro de autorização/ausência.</returns>
         Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Conta quantas mensagens não lidas existem para o usuário informado.
+        /// </summary>
+        /// <param name="usuarioId">Identificador do destinatário.</param>
+        /// <param name="cancellationToken">Token de cancelamento.</param>
+        /// <returns>Total de mensagens pendentes de leitura.</returns>
         Task<int> ContarNaoLidasAsync(int usuarioId, CancellationToken cancellationToken = default);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/Interfaces/IUsuarioService.cs
@@ -5,13 +5,65 @@ using Sistema.CORE.Common;
 
 namespace Sistema.CORE.Services.Interfaces;
 
+/// <summary>
+/// Serviço responsável por operações de usuário e auditoria das ações executadas.
+/// </summary>
 public interface IUsuarioService
 {
+    /// <summary>
+    /// Recupera todos os usuários ativos aplicando paginação.
+    /// </summary>
+    /// <param name="page">Página solicitada (base 1).</param>
+    /// <param name="pageSize">Quantidade de registros por página.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado paginado de usuários.</returns>
     Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Busca um usuário pelo identificador único.
+    /// </summary>
+    /// <param name="id">Identificador do usuário.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Usuário encontrado ou nulo.</returns>
     Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Busca um usuário pelo CPF.
+    /// </summary>
+    /// <param name="cpf">CPF do usuário.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Usuário localizado ou nulo.</returns>
     Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Localiza usuário pelo token de redefinição de senha.
+    /// </summary>
+    /// <param name="token">Token emitido para recuperação.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Usuário correspondente ou nulo.</returns>
     Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adiciona um novo usuário, registrando logs de sucesso ou conflito de CPF.
+    /// </summary>
+    /// <param name="usuario">Entidade a ser criada.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado contendo sucesso e a entidade criada quando aplicável.</returns>
     Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atualiza dados de um usuário e registra o resultado da operação no log.
+    /// </summary>
+    /// <param name="usuario">Usuário com informações atualizadas.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado sinalizando sucesso ou conflito de CPF.</returns>
     Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove um usuário pelo identificador e registra o evento de exclusão.
+    /// </summary>
+    /// <param name="id">Identificador do usuário.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Resultado da operação.</returns>
     Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Services/MensagemService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/MensagemService.cs
@@ -11,19 +11,10 @@ using Sistema.CORE.Services.Interfaces;
 
 namespace Sistema.CORE.Services
 {
-    /// <summary>
-    /// Serviço de mensagens responsável por consultas, envio e atualização de status de leitura.
-    /// </summary>
     public class MensagemService(IUnitOfWork uow) : IMensagemService
     {
         private readonly IUnitOfWork _uow = uow;
 
-        /// <summary>
-        /// Valida assunto e corpo de uma mensagem garantindo preenchimento e limites de tamanho aceitáveis.
-        /// </summary>
-        /// <param name="assunto">Texto informado como assunto.</param>
-        /// <param name="corpo">Corpo detalhado da mensagem.</param>
-        /// <returns>Resultado indicando sucesso ou falha com a justificativa.</returns>
         private static OperationResult<int> ValidarConteudo(string assunto, string corpo)
         {
             if (string.IsNullOrWhiteSpace(assunto))
@@ -38,18 +29,6 @@ namespace Sistema.CORE.Services
             return new OperationResult<int>(true, string.Empty);
         }
 
-        /// <summary>
-        /// Busca mensagens recebidas pelo usuário aplicando filtros opcionais e paginação.
-        /// </summary>
-        /// <param name="usuarioId">Identificador do destinatário.</param>
-        /// <param name="page">Página solicitada (base 1).</param>
-        /// <param name="pageSize">Quantidade de itens por página.</param>
-        /// <param name="remetenteId">Filtro opcional pelo remetente.</param>
-        /// <param name="palavraChave">Termo opcional pesquisado em assunto ou corpo.</param>
-        /// <param name="inicio">Data inicial do período desejado.</param>
-        /// <param name="fim">Data final do período desejado.</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>Resultado paginado com as mensagens encontradas.</returns>
         public async Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null, CancellationToken cancellationToken = default)
         {
             IQueryable<Mensagem> query = _uow.Mensagens.Query()
@@ -73,14 +52,6 @@ namespace Sistema.CORE.Services
             return new PagedResult<Mensagem>(items, total, page, pageSize);
         }
 
-        /// <summary>
-        /// Busca mensagens enviadas por um usuário aplicando paginação padrão.
-        /// </summary>
-        /// <param name="usuarioId">Identificador do remetente.</param>
-        /// <param name="page">Página solicitada (base 1).</param>
-        /// <param name="pageSize">Quantidade máxima de itens por página.</param>
-        /// <param name="cancellationToken">Token de cancelamento da operação assíncrona.</param>
-        /// <returns>Lista paginada das mensagens enviadas.</returns>
         public async Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize, CancellationToken cancellationToken = default)
         {
             var query = _uow.Mensagens.Query()
@@ -93,21 +64,8 @@ namespace Sistema.CORE.Services
             return new PagedResult<Mensagem>(items, total, page, pageSize);
         }
 
-        /// <summary>
-        /// Obtém uma mensagem específica incluindo dados de remetente, destinatário e mensagem pai.
-        /// </summary>
-        /// <param name="id">Identificador único da mensagem.</param>
-        /// <param name="cancellationToken">Token de cancelamento da operação assíncrona.</param>
-        /// <returns>Instância encontrada ou nula quando inexistente.</returns>
         public Task<Mensagem?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Mensagens.GetByIdAsync(id, cancellationToken);
 
-        /// <summary>
-        /// Recupera toda a conversa relacionada a uma mensagem desde a origem, validando a participação do usuário.
-        /// </summary>
-        /// <param name="mensagemId">Mensagem base da consulta.</param>
-        /// <param name="usuarioId">Usuário que solicita a conversa (precisa ser participante).</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>A mensagem raiz com suas respostas encadeadas ou nulo caso o usuário não tenha acesso.</returns>
         public async Task<Mensagem?> BuscarConversaAsync(int mensagemId, int usuarioId, CancellationToken cancellationToken = default)
         {
             var baseQuery = _uow.Mensagens.Query()
@@ -157,16 +115,6 @@ namespace Sistema.CORE.Services
             return raiz;
         }
 
-        /// <summary>
-        /// Envia uma nova mensagem para um destinatário validando conteúdo e existência dos usuários envolvidos.
-        /// </summary>
-        /// <param name="remetenteId">Identificador opcional do remetente.</param>
-        /// <param name="destinatarioId">Identificador do destinatário obrigatório.</param>
-        /// <param name="assunto">Assunto a ser enviado.</param>
-        /// <param name="corpo">Corpo do texto da mensagem.</param>
-        /// <param name="mensagemPaiId">Identificador opcional da mensagem respondida.</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>Resultado contendo sucesso e o id da nova mensagem.</returns>
         public async Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default)
         {
             var validacao = ValidarConteudo(assunto, corpo);
@@ -201,16 +149,6 @@ namespace Sistema.CORE.Services
             return new OperationResult<int>(true, string.Empty, msg.Id);
         }
 
-        /// <summary>
-        /// Envia uma mensagem para todos os usuários de um perfil, retornando a lista de ids criados.
-        /// </summary>
-        /// <param name="remetenteId">Identificador opcional do remetente.</param>
-        /// <param name="perfilId">Perfil dos destinatários.</param>
-        /// <param name="assunto">Assunto compartilhado.</param>
-        /// <param name="corpo">Corpo compartilhado.</param>
-        /// <param name="mensagemPaiId">Mensagem à qual esta comunicação responde, quando aplicável.</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>Resultado com os ids das mensagens criadas ou erro contextualizado.</returns>
         public async Task<OperationResult<List<int>>> EnviarParaPerfilAsync(int? remetenteId, int perfilId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default)
         {
             var validacao = ValidarConteudo(assunto, corpo);
@@ -251,13 +189,6 @@ namespace Sistema.CORE.Services
             return new OperationResult<List<int>>(true, string.Empty, ids);
         }
 
-        /// <summary>
-        /// Marca uma mensagem como lida pelo destinatário, registrando a data de leitura.
-        /// </summary>
-        /// <param name="id">Identificador da mensagem.</param>
-        /// <param name="usuarioId">Usuário que está realizando a leitura.</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>Resultado indicando sucesso ou erro de autorização/ausência.</returns>
         public async Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId, CancellationToken cancellationToken = default)
         {
             var msg = await _uow.Mensagens.GetByIdAsync(id, cancellationToken);
@@ -273,12 +204,6 @@ namespace Sistema.CORE.Services
             return new OperationResult(true, string.Empty);
         }
 
-        /// <summary>
-        /// Conta quantas mensagens não lidas existem para o usuário informado.
-        /// </summary>
-        /// <param name="usuarioId">Identificador do destinatário.</param>
-        /// <param name="cancellationToken">Token de cancelamento.</param>
-        /// <returns>Total de mensagens pendentes de leitura.</returns>
         public async Task<int> ContarNaoLidasAsync(int usuarioId, CancellationToken cancellationToken = default)
         {
             var total = await _uow.Mensagens.Query().CountAsync(m => m.DestinatarioId == usuarioId && !m.Lida, cancellationToken);

--- a/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
+++ b/2 - Dominio/Sistema.CORE/Services/UsuarioService.cs
@@ -7,54 +7,20 @@ using Sistema.CORE.Services.Interfaces;
 
 namespace Sistema.CORE.Services;
 
-/// <summary>
-/// Serviço responsável por operações de usuário e auditoria das ações executadas.
-/// </summary>
 public class UsuarioService(IUnitOfWork uow, ILogService log) : IUsuarioService
 {
     private readonly IUnitOfWork _uow = uow;
     private readonly ILogService _log = log;
 
-    /// <summary>
-    /// Recupera todos os usuários ativos aplicando paginação.
-    /// </summary>
-    /// <param name="page">Página solicitada (base 1).</param>
-    /// <param name="pageSize">Quantidade de registros por página.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado paginado de usuários.</returns>
     public Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default) =>
         _uow.Usuarios.BuscarTodosAsync(page, pageSize, cancellationToken);
 
-    /// <summary>
-    /// Busca um usuário pelo identificador único.
-    /// </summary>
-    /// <param name="id">Identificador do usuário.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Usuário encontrado ou nulo.</returns>
     public Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorIdAsync(id, cancellationToken);
 
-    /// <summary>
-    /// Busca um usuário pelo CPF.
-    /// </summary>
-    /// <param name="cpf">CPF do usuário.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Usuário localizado ou nulo.</returns>
     public Task<Usuario?> BuscarPorCpfAsync(string cpf, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);
 
-    /// <summary>
-    /// Localiza usuário pelo token de redefinição de senha.
-    /// </summary>
-    /// <param name="token">Token emitido para recuperação.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Usuário correspondente ou nulo.</returns>
     public Task<Usuario?> BuscarPorResetTokenAsync(string token, CancellationToken cancellationToken = default) => _uow.Usuarios.BuscarPorResetTokenAsync(token, cancellationToken);
 
-    /// <summary>
-    /// Adiciona um novo usuário, registrando logs de sucesso ou conflito de CPF.
-    /// </summary>
-    /// <param name="usuario">Entidade a ser criada.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado contendo sucesso e a entidade criada quando aplicável.</returns>
     public async Task<OperationResult<Usuario>> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
         var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
@@ -71,12 +37,6 @@ public class UsuarioService(IUnitOfWork uow, ILogService log) : IUsuarioService
         return new OperationResult<Usuario>(true, "Usuário criado com sucesso", created);
     }
 
-    /// <summary>
-    /// Atualiza dados de um usuário e registra o resultado da operação no log.
-    /// </summary>
-    /// <param name="usuario">Usuário com informações atualizadas.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado sinalizando sucesso ou conflito de CPF.</returns>
     public async Task<OperationResult> AtualizarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {
         var existing = await _uow.Usuarios.BuscarPorCpfAsync(usuario.Cpf, cancellationToken);
@@ -93,12 +53,6 @@ public class UsuarioService(IUnitOfWork uow, ILogService log) : IUsuarioService
         return new OperationResult(true, "Usuário atualizado com sucesso");
     }
 
-    /// <summary>
-    /// Remove um usuário pelo identificador e registra o evento de exclusão.
-    /// </summary>
-    /// <param name="id">Identificador do usuário.</param>
-    /// <param name="cancellationToken">Token de cancelamento.</param>
-    /// <returns>Resultado da operação.</returns>
     public async Task<OperationResult> RemoverAsync(int id, CancellationToken cancellationToken = default)
     {
         await _uow.Usuarios.RemoverAsync(id, cancellationToken);


### PR DESCRIPTION
## Summary
- move XML documentation from service implementations into their interfaces
- clean service classes by removing inline XML docs and keeping interfaces as the documentation source
- add missing namespace import for collections in the message service interface

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954380c082c832cb74ed76b92f33faa)