### PR TITLE
Ajusta variável de largura da sidebar e padding dinâmico do header

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.scss
@@ -8,6 +8,7 @@
   --rightbar-bg: #f8f9fa;
   --footer-bg: #{v.$azul};
   --iconbar-width: 64px;
+  --sidebar-width: 260px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -50,6 +50,17 @@
 
         const classesTexto = ['text-white', 'text-dark'];
 
+        const atualizarEspacamentoHeader = () => {
+            if (!$headerEl.length) return;
+
+            const headerFixo = $headerEl.hasClass('fixed-top');
+            const alturaHeader = headerFixo
+                ? Math.ceil(($headerEl.outerHeight ? $headerEl.outerHeight() : $headerEl[0]?.offsetHeight) || 0)
+                : 0;
+
+            document.body.style.paddingTop = headerFixo && alturaHeader ? `${alturaHeader}px` : '';
+        };
+
         const normalizarHex = (valor) => {
             if (!valor) return null;
             const cor = valor.trim();
@@ -144,7 +155,8 @@
 
             if ($headerEl.length) {
                 $headerEl.toggleClass('fixed-top', headerFixed);
-                $body.toggleClass('pt-5', headerFixed);
+                $body.removeClass('pt-5');
+                atualizarEspacamentoHeader();
                 $('#HeaderFixo').prop('checked', headerFixed);
             }
 
@@ -388,6 +400,18 @@
                     });
             });
         }
+
+        let resizeRaf = null;
+        window.addEventListener('resize', () => {
+            if (resizeRaf) {
+                cancelAnimationFrame(resizeRaf);
+            }
+
+            resizeRaf = window.requestAnimationFrame(() => {
+                resizeRaf = null;
+                atualizarEspacamentoHeader();
+            });
+        });
 
     });
 })();


### PR DESCRIPTION
## Summary
- define a variável `--sidebar-width` no `site.scss` para manter a largura correta da barra lateral
- calcula o espaçamento superior do corpo com base na altura real do cabeçalho quando ele está fixo, removendo a dependência de `pt-5`
- recalcula o padding do header fixo em eventos de resize para evitar deslocamentos em diferentes tamanhos de tela

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69543a7bbc24832c9549b402929a41e7)