### PR TITLE
Responsive sidebar and mobile menu toggle for mmenu; adapt CSS and JS for desktop breakpoint

### DIFF
--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -82,7 +82,12 @@
     <div class="d-flex flex-column min-vh-100">
         <header class="navbar @headerNavbarClass @headerFixedClass header-bg">
             <div class="container-fluid">
-                <a class="navbar-brand @headerText" asp-controller="Home" asp-action="Index">Sistema.MVC</a>
+                <div class="d-flex align-items-center gap-2">
+                    <a class="btn btn-link @headerText mobile-menu-toggle" href="#sidebarMenu" aria-label="Abrir menu" title="Abrir menu">
+                        <i class="bi bi-list"></i>
+                    </a>
+                    <a class="navbar-brand @headerText" asp-controller="Home" asp-action="Index">Sistema.MVC</a>
+                </div>
                 <div class="ms-auto d-flex align-items-center">
                     <button class="btn btn-link @headerText" type="button" id="temaToggle"><i class="bi bi-palette"></i></button>
                     <div class="dropdown">

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -92,6 +92,8 @@ footer.footer {
   --footer-bg: #0d6efd;
   --iconbar-width: 64px;
   --sidebar-width: 260px;
+  --mm-max-size: var(--sidebar-width);
+  --mm-sidebar-expanded-size: var(--sidebar-width);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -308,16 +310,42 @@ footer.footer {
   outline-offset: 2px;
 }
 
+
+.mobile-menu-toggle {
+  display: none;
+}
+
+@media (max-width: 991.98px) {
+  .mobile-menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .app-menu {
+    flex: 0 0 0;
+    max-width: 0;
+    width: 0;
+    min-width: 0;
+    border-right: 0;
+    box-shadow: none;
+  }
+}
+
+@media (min-width: 992px) {
+  .app-menu {
+    flex: 0 0 var(--sidebar-width);
+    max-width: var(--sidebar-width);
+    width: var(--sidebar-width);
+  }
+}
 @media (max-width: 991.98px) {
   .app-iconbar {
     display: none;
   }
 
-  .app-menu {
-    flex-basis: var(--sidebar-width);
-    max-width: var(--sidebar-width);
-    width: var(--sidebar-width);
-  }
 }
 
 /*# sourceMappingURL=site.css.map */

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -47,6 +47,7 @@
 
         let mmApi = null;
         const expandedStateKey = 'mmenuExpandedState';
+        const desktopMedia = window.matchMedia('(min-width: 992px)');
 
         const classesTexto = ['text-white', 'text-dark'];
 
@@ -54,9 +55,7 @@
             if (!$headerEl.length) return;
 
             const headerFixo = $headerEl.hasClass('fixed-top');
-            const alturaHeader = headerFixo
-                ? Math.ceil(($headerEl.outerHeight ? $headerEl.outerHeight() : $headerEl[0]?.offsetHeight) || 0)
-                : 0;
+            const alturaHeader = headerFixo ? Math.ceil($headerEl.outerHeight() || $headerEl[0]?.offsetHeight || 0) : 0;
 
             document.body.style.paddingTop = headerFixo && alturaHeader ? `${alturaHeader}px` : '';
         };
@@ -180,8 +179,12 @@
                 window.sessionStorage.setItem(expandedStateKey, tema.menuLateralExpandido ? 'open' : 'closed');
 
                 if (mmApi) {
-                    if (tema.menuLateralExpandido) {
-                        mmApi.open();
+                    if (desktopMedia.matches) {
+                        if (tema.menuLateralExpandido) {
+                            mmApi.open();
+                        } else {
+                            mmApi.close();
+                        }
                     } else {
                         mmApi.close();
                     }
@@ -195,8 +198,25 @@
 
         const sidebarMenu = document.getElementById('sidebarMenu');
         const initialMenuExpanded = sidebarMenu?.dataset.menuExpanded === 'true';
+        const initialTheme = {
+            modoEscuro: serverTheme === 'dark',
+            menuLateralExpandido: initialMenuExpanded
+        };
 
-        aplicarTema({ modoEscuro: serverTheme === 'dark', menuLateralExpandido: initialMenuExpanded });
+        const atualizarEstadoMenuResponsivo = () => {
+            if (!mmApi) return;
+
+            if (desktopMedia.matches) {
+                const shouldOpen = $('#MenuLateralExpandido').is(':checked');
+                if (shouldOpen) {
+                    mmApi.open();
+                } else {
+                    mmApi.close();
+                }
+            } else {
+                mmApi.close();
+            }
+        };
 
         const $temaToggle = $('#temaToggle');
         const $temaSidebar = $('#temaSidebar');
@@ -227,10 +247,6 @@
         }
 
         if (sidebarMenu && window.Mmenu) {
-            const homeUrl = sidebarMenu.dataset.homeUrl || '/';
-            const configUrl = sidebarMenu.dataset.configUrl || '/Configuracao/Index';
-            const themeUrl = sidebarMenu.dataset.themeUrl || '/Tema/Edit';
-            const logoutUrl = sidebarMenu.dataset.logoutUrl || '/Account/Logout';
             const isDarkMode = (document.body.getAttribute('data-bs-theme') || 'light') === 'dark';
 
             if (typeof initialMenuExpanded === 'boolean') {
@@ -244,7 +260,7 @@
                     visible: 1
                 },
                 setSelected: {
-                    hover: true,
+                    hover: false,
                     parent: true,
                     current: true
                 },
@@ -265,42 +281,24 @@
                 },
                 sidebar: {
                     expanded: {
-                        use: true,
+                        use: '(min-width: 992px)',
                         initial: initialMenuExpanded ? 'open' : 'closed'
                     }
                 },
                 iconbar: {
-                    use: true,
-                    position: 'left',
-                    top: [
-                        `<a href="${homeUrl}" title="Home"><i class="bi bi-house"></i></a>`
-                    ],
-                    bottom: [
-                        `<a href="${logoutUrl}" title="Sair"><i class="bi bi-box-arrow-right"></i></a>`,
-                        `<a href="${configUrl}" title="Configurações"><i class="bi bi-gear"></i></a>`,
-                        `<a href="${themeUrl}" title="Tema"><i class="bi bi-palette"></i></a>`
-                    ]
+                    use: false
                 }
             });
 
             mmApi = mmenu.API;
 
-            mmApi.bind('setSelected:after', () => {
-                sidebarMenu.querySelectorAll('.mm-listitem__btn, .mm-listitem__text')
-                    .forEach(el => el.classList.remove('hovering'));
+            desktopMedia.addEventListener('change', () => {
+                atualizarEstadoMenuResponsivo();
             });
-
-            sidebarMenu.addEventListener('mouseover', (ev) => {
-                const target = ev.target;
-                if (!(target instanceof HTMLElement)) return;
-                const listItem = target.closest('.mm-listitem');
-                if (listItem) {
-                    mmApi.setSelected(listItem);
-                }
-            });
-
-            aplicarTema({ menuLateralExpandido: initialMenuExpanded });
         }
+
+        aplicarTema(initialTheme);
+        atualizarEstadoMenuResponsivo();
 
         $('input[name="ModoEscuro"]').on('change', function () {
             aplicarTema({ modoEscuro: $(this).val() === 'true' });


### PR DESCRIPTION
### Motivation
- Improve mobile navigation by adding an explicit mobile menu toggle and ensuring the sidebar behavior adapts to desktop vs mobile breakpoints. 
- Make `mmenu` initialization responsive so the sidebar only auto-expands on larger viewports and remains off-canvas on small screens. 
- Simplify iconbar behavior and update visual spacing handling for fixed header/footer.

### Description
- Added a mobile menu toggle button in the header markup (`_Layout.cshtml`) wrapped with the brand to open `#sidebarMenu` on small screens. 
- Introduced CSS variables `--mm-max-size` and `--mm-sidebar-expanded-size`, added `.mobile-menu-toggle` rules and reworked `.app-menu`/`.app-iconbar` responsive styles to collapse the menu on `< 992px` and restore at `>= 992px`. 
- Updated JS (`site.js`) to use a `desktopMedia` `matchMedia('(min-width: 992px)')`, created `atualizarEstadoMenuResponsivo` to open/close `mmApi` based on breakpoint, and applied an `initialTheme` when initializing UI. 
- Adjusted `mmenu` options: set `setSelected.hover` to `false`, changed `sidebar.expanded.use` to `'(min-width: 992px)'`, disabled the `iconbar` (`use: false`), removed hover-based selection logic and replaced it with breakpoint-driven open/close handling, and bound a listener to `desktopMedia.change` to update menu state. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdec47ce0832ca291568a0fb8388c)