### PR TITLE
Add communication hub (posts/avisos/reactions) and enhanced auditing with retention, correlation and fallback

### DIFF
--- a/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/LogController.cs
@@ -19,9 +19,18 @@ public class LogController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, CancellationToken cancellationToken)
-    {
+    public async Task<IEnumerable<Log>> Get([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, [FromQuery] LogModulo? modulo, CancellationToken cancellationToken)
+        => await _logs.BuscarFiltradosAsync(inicio, fim, tipo, modulo, cancellationToken);
 
-        return await _logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
-    }
+    [HttpGet("acesso")]
+    public async Task<IEnumerable<Log>> GetAcesso([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, CancellationToken cancellationToken)
+        => await _logs.BuscarAcessoAsync(inicio, fim, tipo, cancellationToken);
+
+    [HttpGet("comunicacao")]
+    public async Task<IEnumerable<Log>> GetComunicacao([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, CancellationToken cancellationToken)
+        => await _logs.BuscarComunicacaoAsync(inicio, fim, tipo, cancellationToken);
+
+    [HttpGet("administracao")]
+    public async Task<IEnumerable<Log>> GetAdministracao([FromQuery] DateTime? inicio, [FromQuery] DateTime? fim, [FromQuery] LogTipo? tipo, CancellationToken cancellationToken)
+        => await _logs.BuscarAdministracaoAsync(inicio, fim, tipo, cancellationToken);
 }

--- a/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
+++ b/0 - Apresentacao/Sistema.API/Controllers/MensagemController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Sistema.APP.DTOs;
 using Sistema.APP.Services.Interfaces;
-using System;
+using Sistema.CORE.Entities;
 using System.Security.Claims;
 
 namespace Sistema.API.Controllers
@@ -50,6 +50,33 @@ namespace Sistema.API.Controllers
             return Ok(new { result.TotalCount, result.Page, result.PageSize, Items = dto });
         }
 
+        [HttpGet("feed")]
+        public async Task<IActionResult> Feed(int page = 1, int pageSize = 20, PublicacaoTipo? tipo = null, int? perfilId = null, bool somenteNaoLidas = false, AvisoPrioridade? prioridadeMinima = null, string? palavraChave = null)
+        {
+            var usuarioId = ObterUsuarioIdAutenticado();
+            if (usuarioId is null) return Unauthorized();
+            var cancellationToken = HttpContext.RequestAborted;
+            var filtro = new FeedFiltroDto
+            {
+                Tipo = tipo,
+                PerfilId = perfilId,
+                SomenteNaoLidas = somenteNaoLidas,
+                PrioridadeMinima = prioridadeMinima,
+                PalavraChave = palavraChave
+            };
+            var result = await _mensagemService.BuscarFeedAsync(usuarioId.Value, page, pageSize, filtro, cancellationToken);
+            var dto = result.Items.Select(m =>
+            {
+                var item = _mapper.Map<MensagemDto>(m);
+                item.PodeResponder = true;
+                item.PodeReagir = true;
+                item.PodeModerar = false;
+                return item;
+            });
+
+            return Ok(new { result.TotalCount, result.Page, result.PageSize, Items = dto });
+        }
+
         [HttpGet("{id}")]
         public async Task<IActionResult> Get(int id)
         {
@@ -57,7 +84,7 @@ namespace Sistema.API.Controllers
             if (usuarioId is null) return Unauthorized();
             var cancellationToken = HttpContext.RequestAborted;
             var msg = await _mensagemService.BuscarPorIdAsync(id, cancellationToken);
-            if (msg == null || (msg.RemetenteId != usuarioId.Value && msg.DestinatarioId != usuarioId.Value))
+            if (msg == null)
                 return NotFound();
             return Ok(_mapper.Map<MensagemDto>(msg));
         }
@@ -79,6 +106,14 @@ namespace Sistema.API.Controllers
             var usuarioId = ObterUsuarioIdAutenticado();
             if (usuarioId is null) return Unauthorized();
             var cancellationToken = HttpContext.RequestAborted;
+
+            if (dto.Tipo != PublicacaoTipo.MensagemDireta)
+            {
+                var resultadoPublicacao = await _mensagemService.CriarPublicacaoAsync(usuarioId.Value, dto, cancellationToken);
+                if (!resultadoPublicacao.Success) return BadRequest(resultadoPublicacao.Message);
+                return CreatedAtAction(nameof(Get), new { id = resultadoPublicacao.Data }, resultadoPublicacao.Data);
+            }
+
             if (dto.PerfilId.HasValue)
             {
                 var resultadoGrupo = await _mensagemService.EnviarParaPerfilAsync(usuarioId, dto.PerfilId.Value, dto.Assunto, dto.Corpo, dto.MensagemPaiId, cancellationToken);
@@ -86,7 +121,10 @@ namespace Sistema.API.Controllers
                 return Created(string.Empty, resultadoGrupo.Data);
             }
 
-            var result = await _mensagemService.EnviarAsync(usuarioId, dto.DestinatarioId, dto.Assunto, dto.Corpo, dto.MensagemPaiId, cancellationToken);
+            if (!dto.DestinatarioId.HasValue)
+                return BadRequest("Destinatário é obrigatório para mensagem direta.");
+
+            var result = await _mensagemService.EnviarAsync(usuarioId, dto.DestinatarioId.Value, dto.Assunto, dto.Corpo, dto.MensagemPaiId, cancellationToken);
             if (!result.Success) return BadRequest(result.Message);
             return CreatedAtAction(nameof(Get), new { id = result.Data }, result.Data);
         }
@@ -98,6 +136,17 @@ namespace Sistema.API.Controllers
             if (usuarioId is null) return Unauthorized();
             var cancellationToken = HttpContext.RequestAborted;
             var result = await _mensagemService.MarcarComoLidaAsync(id, usuarioId.Value, cancellationToken);
+            if (!result.Success) return BadRequest(result.Message);
+            return NoContent();
+        }
+
+        [HttpPost("{id}/reacoes")]
+        public async Task<IActionResult> Reagir(int id, [FromBody] ReagirPublicacaoDto dto)
+        {
+            var usuarioId = ObterUsuarioIdAutenticado();
+            if (usuarioId is null) return Unauthorized();
+            var cancellationToken = HttpContext.RequestAborted;
+            var result = await _mensagemService.ReagirAsync(id, usuarioId.Value, dto.TipoReacao, cancellationToken);
             if (!result.Success) return BadRequest(result.Message);
             return NoContent();
         }

--- a/0 - Apresentacao/Sistema.API/Program.cs
+++ b/0 - Apresentacao/Sistema.API/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddInfraestrutura(builder.Configuration);
 builder.Services.AddAplicacao();
+builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -40,6 +41,20 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 var app = builder.Build();
+
+app.Use(async (context, next) =>
+{
+    const string correlationHeader = "X-Correlation-ID";
+    var correlationId = context.Request.Headers[correlationHeader].FirstOrDefault();
+    if (string.IsNullOrWhiteSpace(correlationId))
+    {
+        correlationId = Guid.NewGuid().ToString("N");
+    }
+
+    context.TraceIdentifier = correlationId;
+    context.Response.Headers[correlationHeader] = correlationId;
+    await next();
+});
 
 if (app.Environment.IsDevelopment())
 {

--- a/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/AccountController.cs
@@ -4,18 +4,21 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Sistema.CORE.Entities;
 using Sistema.APP.Services.Interfaces;
+using Sistema.CORE.Repositories.Interfaces;
 using Sistema.MVC.Models;
 using System.Globalization;
 using System.Security.Claims;
 
 namespace Sistema.MVC.Controllers;
 
-public class AccountController(IUsuarioAppService usuarioService, IPasswordHasher<Usuario> hasher, IEmailAppService emailService, ILogger<AccountController> logger) : Controller
+public class AccountController(IUsuarioAppService usuarioService, IPasswordHasher<Usuario> hasher, IEmailAppService emailService, ILogger<AccountController> logger, ILogAppService logService, IUnitOfWork uow) : Controller
 {
     private readonly IUsuarioAppService _usuarioService = usuarioService;
     private readonly IPasswordHasher<Usuario> _hasher = hasher;
     private readonly IEmailAppService _emailService = emailService;
     private readonly ILogger<AccountController> _logger = logger;
+    private readonly ILogAppService _logService = logService;
+    private readonly IUnitOfWork _uow = uow;
 
 	private int? ObterUsuarioId()
     {
@@ -52,6 +55,7 @@ public class AccountController(IUsuarioAppService usuarioService, IPasswordHashe
         var usuario = await _usuarioService.BuscarPorCpfAsync(model.Cpf);
         if (usuario is null)
         {
+            await RegistrarLogAcessoAsync(nameof(Usuario), "LoginMVC", false, "Credenciais inválidas", LogTipo.Informacao, model.Cpf, "Usuário não encontrado");
             ModelState.AddModelError(string.Empty, "Credenciais inválidas");
             return View(model);
         }
@@ -59,12 +63,14 @@ public class AccountController(IUsuarioAppService usuarioService, IPasswordHashe
         var result = _hasher.VerifyHashedPassword(usuario, usuario.SenhaHash, model.Senha);
         if (result != PasswordVerificationResult.Success)
         {
+            await RegistrarLogAcessoAsync(nameof(Usuario), "LoginMVC", false, "Credenciais inválidas", LogTipo.Informacao, usuario.Cpf, "Senha inválida");
             ModelState.AddModelError(string.Empty, "Credenciais inválidas");
             return View(model);
         }
 
         if (!usuario.Ativo)
         {
+            await RegistrarLogAcessoAsync(nameof(Usuario), "LoginMVC", false, "Usuário inativo", LogTipo.Informacao, usuario.Cpf, null);
             ModelState.AddModelError(string.Empty, "Usuário inativo");
             return View(model);
         }
@@ -81,6 +87,7 @@ public class AccountController(IUsuarioAppService usuarioService, IPasswordHashe
         await HttpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
             new ClaimsPrincipal(identity));
+        await RegistrarLogAcessoAsync(nameof(Usuario), "LoginMVC", true, "Login MVC realizado com sucesso", LogTipo.Sucesso, usuario.Cpf, null);
         return RedirectToAction("Index", "Home");
     }
 
@@ -255,9 +262,17 @@ public class AccountController(IUsuarioAppService usuarioService, IPasswordHashe
         return View(new ChangePasswordViewModel());
     }
 
+    private async Task RegistrarLogAcessoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe)
+    {
+        await _logService.RegistrarAcessoAsync(entidade, operacao, sucesso, mensagem, tipo, usuario, detalhe, HttpContext.RequestAborted);
+        await _uow.ConfirmarAsync(HttpContext.RequestAborted);
+    }
+
     [HttpGet]
     public async Task<IActionResult> Logout()
     {
+        var usuario = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? HttpContext.Session.GetString("UserName") ?? "anonimo";
+        await RegistrarLogAcessoAsync(nameof(Usuario), "LogoutMVC", true, "Logout realizado", LogTipo.Sucesso, usuario, null);
         HttpContext.Session.Clear();
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         return RedirectToAction("Login");

--- a/0 - Apresentacao/Sistema.MVC/Controllers/MensagemController.cs
+++ b/0 - Apresentacao/Sistema.MVC/Controllers/MensagemController.cs
@@ -1,9 +1,12 @@
 using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Sistema.APP.DTOs;
 using Sistema.APP.Services.Interfaces;
+using Sistema.CORE.Entities;
 using Sistema.MVC.Models;
 using System.Security.Claims;
+using System.Globalization;
 
 namespace Sistema.MVC.Controllers
 {
@@ -17,7 +20,7 @@ namespace Sistema.MVC.Controllers
         private readonly IPerfilAppService _perfilService = perfilService;
         private readonly IMapper _mapper = mapper;
 
-		private int? ObterUsuarioId()
+        private int? ObterUsuarioId()
         {
             var userId = HttpContext.Session.GetInt32("UserId");
             if (userId.HasValue)
@@ -74,26 +77,43 @@ namespace Sistema.MVC.Controllers
                 MensagemPaiId = mensagemPaiId,
                 Assunto = assunto ?? string.Empty,
                 DestinatarioSelecionados = destinatariosSelecionados?.Distinct().ToList() ?? [],
-                Destinatarios = opcoesDestinatarios
+                Destinatarios = opcoesDestinatarios,
+                Perfis = perfis.Items.OrderBy(p => p.Nome).Select(p => new SelectListItem(p.Nome, p.Id.ToString(CultureInfo.InvariantCulture)))
             };
         }
 
         [HttpGet]
-        public async Task<IActionResult> Index(int page = 1, int pageSize = 20, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null)
+        public async Task<IActionResult> Index(int page = 1, int pageSize = 20, PublicacaoTipo? tipo = null, int? perfilId = null, bool somenteNaoLidas = false, AvisoPrioridade? prioridadeMinima = null, string? palavraChave = null)
         {
             var userId = ObterUsuarioId();
             if (userId is null) return RedirectToAction("Login", "Account");
-            var result = await _mensagemService.BuscarCaixaEntradaAsync(userId.Value, page, pageSize, remetenteId, palavraChave, inicio, fim);
+
+            var result = await _mensagemService.BuscarFeedAsync(userId.Value, page, pageSize, new FeedFiltroDto
+            {
+                Tipo = tipo,
+                PerfilId = perfilId,
+                SomenteNaoLidas = somenteNaoLidas,
+                PrioridadeMinima = prioridadeMinima,
+                PalavraChave = palavraChave
+            });
+
             var model = new MensagemViewModel
             {
-                Mensagens = [.. result.Items.Select(m => _mapper.Map<APP.DTOs.MensagemDto>(m))],
+                Mensagens = [.. result.Items.Select(m =>
+                {
+                    var dto = _mapper.Map<MensagemDto>(m);
+                    dto.PodeReagir = true;
+                    dto.PodeResponder = true;
+                    return dto;
+                })],
                 Page = result.Page,
                 PageSize = result.PageSize,
                 TotalItems = result.TotalCount,
-                RemetenteId = remetenteId,
-                PalavraChave = palavraChave,
-                Inicio = inicio,
-                Fim = fim
+                Tipo = tipo,
+                PerfilId = perfilId,
+                SomenteNaoLidas = somenteNaoLidas,
+                PrioridadeMinima = prioridadeMinima,
+                PalavraChave = palavraChave
             };
             return View(model);
         }
@@ -139,60 +159,101 @@ namespace Sistema.MVC.Controllers
             {
                 var viewModel = await CriarNovaMensagemViewModelAsync(model.MensagemPaiId, model.DestinatarioSelecionados, model.Assunto);
                 model.Destinatarios = viewModel.Destinatarios;
+                model.Perfis = viewModel.Perfis;
                 return View(model);
             }
 
-            var errosEnvio = new List<string>();
-
-            foreach (var destinatario in model.DestinatarioSelecionados.Distinct())
+            if (model.Tipo == PublicacaoTipo.MensagemDireta)
             {
-                if (destinatario.StartsWith(PerfilPrefixo, StringComparison.OrdinalIgnoreCase))
+                var errosEnvio = new List<string>();
+
+                foreach (var destinatario in model.DestinatarioSelecionados.Distinct())
                 {
-                    if (!int.TryParse(destinatario.Replace(PerfilPrefixo, string.Empty), out var perfilId))
+                    if (destinatario.StartsWith(PerfilPrefixo, StringComparison.OrdinalIgnoreCase))
                     {
-                        errosEnvio.Add($"Destino inválido: {destinatario}.");
-                        continue;
+                        if (!int.TryParse(destinatario.Replace(PerfilPrefixo, string.Empty), out var perfilId))
+                        {
+                            errosEnvio.Add($"Destino inválido: {destinatario}.");
+                            continue;
+                        }
+
+                        var resultadoPerfil = await _mensagemService.EnviarParaPerfilAsync(remetenteId.Value, perfilId, model.Assunto, model.Corpo, model.MensagemPaiId);
+                        if (!resultadoPerfil.Success)
+                        {
+                            errosEnvio.Add(resultadoPerfil.Message);
+                        }
+                    }
+                    else if (destinatario.StartsWith(UsuarioPrefixo, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!int.TryParse(destinatario.Replace(UsuarioPrefixo, string.Empty), out var destinatarioId))
+                        {
+                            errosEnvio.Add($"Destino inválido: {destinatario}.");
+                            continue;
+                        }
+
+                        var resultadoDestinatario = await _mensagemService.EnviarAsync(remetenteId.Value, destinatarioId, model.Assunto, model.Corpo, model.MensagemPaiId);
+                        if (!resultadoDestinatario.Success)
+                        {
+                            errosEnvio.Add(resultadoDestinatario.Message);
+                        }
+                    }
+                    else
+                    {
+                        errosEnvio.Add($"Destino não reconhecido: {destinatario}.");
+                    }
+                }
+
+                if (errosEnvio.Count != 0)
+                {
+                    foreach (var erro in errosEnvio)
+                    {
+                        ModelState.AddModelError(string.Empty, erro);
                     }
 
-                    var resultadoPerfil = await _mensagemService.EnviarParaPerfilAsync(remetenteId.Value, perfilId, model.Assunto, model.Corpo, model.MensagemPaiId);
-                    if (!resultadoPerfil.Success)
-                    {
-                        errosEnvio.Add(resultadoPerfil.Message);
-                    }
+                    var viewModel = await CriarNovaMensagemViewModelAsync(model.MensagemPaiId, model.DestinatarioSelecionados, model.Assunto);
+                    model.Destinatarios = viewModel.Destinatarios;
+                    model.Perfis = viewModel.Perfis;
+                    return View(model);
                 }
-                else if (destinatario.StartsWith(UsuarioPrefixo, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (!int.TryParse(destinatario.Replace(UsuarioPrefixo, string.Empty), out var destinatarioId))
-                    {
-                        errosEnvio.Add($"Destino inválido: {destinatario}.");
-                        continue;
-                    }
 
-                    var resultadoDestinatario = await _mensagemService.EnviarAsync(remetenteId.Value, destinatarioId, model.Assunto, model.Corpo, model.MensagemPaiId);
-                    if (!resultadoDestinatario.Success)
-                    {
-                        errosEnvio.Add(resultadoDestinatario.Message);
-                    }
-                }
-                else
-                {
-                    errosEnvio.Add($"Destino não reconhecido: {destinatario}.");
-                }
+                return RedirectToAction(nameof(Index));
             }
 
-            if (errosEnvio.Count != 0)
+            var dto = new NovaMensagemDto
             {
-                foreach (var erro in errosEnvio)
-                {
-                    ModelState.AddModelError(string.Empty, erro);
-                }
+                Tipo = model.Tipo,
+                Assunto = model.Assunto,
+                Corpo = model.Corpo,
+                MensagemPaiId = model.MensagemPaiId,
+                PerfilId = model.PerfilId,
+                AvisoAudiencia = model.AvisoAudiencia,
+                AvisoPrioridade = model.AvisoPrioridade,
+                AvisoValidoAte = model.AvisoValidoAte,
+                Fixada = model.Fixada
+            };
 
+            var resultado = await _mensagemService.CriarPublicacaoAsync(remetenteId.Value, dto);
+            if (!resultado.Success)
+            {
+                ModelState.AddModelError(string.Empty, resultado.Message);
                 var viewModel = await CriarNovaMensagemViewModelAsync(model.MensagemPaiId, model.DestinatarioSelecionados, model.Assunto);
                 model.Destinatarios = viewModel.Destinatarios;
+                model.Perfis = viewModel.Perfis;
                 return View(model);
             }
 
             return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Reagir(int id, TipoReacao tipoReacao)
+        {
+            var userId = ObterUsuarioId();
+            if (userId is null) return RedirectToAction("Login", "Account");
+
+            await _mensagemService.ReagirAsync(id, userId.Value, tipoReacao);
+            return RedirectToAction(nameof(Detalhe), new { id });
         }
 
         [HttpGet]
@@ -202,11 +263,10 @@ namespace Sistema.MVC.Controllers
             if (userId is null) return RedirectToAction("Login", "Account");
             var cancellationToken = HttpContext.RequestAborted;
             var mensagemAtual = await _mensagemService.BuscarPorIdAsync(id, cancellationToken);
-            if (mensagemAtual is null || (mensagemAtual.RemetenteId != userId.Value && mensagemAtual.DestinatarioId != userId.Value))
+            if (mensagemAtual is null)
                 return NotFound();
 
-            if (mensagemAtual.DestinatarioId == userId.Value)
-                await _mensagemService.MarcarComoLidaAsync(id, userId.Value, cancellationToken);
+            await _mensagemService.MarcarComoLidaAsync(id, userId.Value, cancellationToken);
 
             var conversa = await _mensagemService.BuscarConversaAsync(id, userId.Value, cancellationToken);
             if (conversa == null) return NotFound();
@@ -215,7 +275,6 @@ namespace Sistema.MVC.Controllers
             {
                 var naoLidas = EnumerarThread(conversa)
                     .Where(m => m.Id != id)
-                    .Where(m => m.DestinatarioId == userId.Value && !m.Lida)
                     .Select(m => m.Id)
                     .ToList();
 
@@ -225,7 +284,7 @@ namespace Sistema.MVC.Controllers
                 }
             }
 
-            return View(_mapper.Map<APP.DTOs.MensagemThreadDto>(conversa));
+            return View(_mapper.Map<MensagemThreadDto>(conversa));
         }
 
         private static IEnumerable<CORE.Entities.Mensagem> EnumerarThread(CORE.Entities.Mensagem raiz)
@@ -251,7 +310,7 @@ namespace Sistema.MVC.Controllers
             var result = await _mensagemService.BuscarCaixaSaidaAsync(userId.Value, page, pageSize);
             var model = new MensagemViewModel
             {
-                Mensagens = [.. result.Items.Select(m => _mapper.Map<APP.DTOs.MensagemDto>(m))],
+                Mensagens = [.. result.Items.Select(m => _mapper.Map<MensagemDto>(m))],
                 Page = result.Page,
                 PageSize = result.PageSize,
                 TotalItems = result.TotalCount

--- a/0 - Apresentacao/Sistema.MVC/Models/MensagemViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/MensagemViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Sistema.APP.DTOs;
+using Sistema.CORE.Entities;
 
 namespace Sistema.MVC.Models
 {
@@ -14,5 +15,9 @@ namespace Sistema.MVC.Models
         public string? PalavraChave { get; set; }
         public DateTime? Inicio { get; set; }
         public DateTime? Fim { get; set; }
+        public PublicacaoTipo? Tipo { get; set; }
+        public int? PerfilId { get; set; }
+        public bool SomenteNaoLidas { get; set; }
+        public AvisoPrioridade? PrioridadeMinima { get; set; }
     }
 }

--- a/0 - Apresentacao/Sistema.MVC/Models/NovaMensagemViewModel.cs
+++ b/0 - Apresentacao/Sistema.MVC/Models/NovaMensagemViewModel.cs
@@ -1,12 +1,15 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Sistema.CORE.Entities;
 
 namespace Sistema.MVC.Models
 {
     public class NovaMensagemViewModel : IValidatableObject
     {
+        [Display(Name = "Tipo de publicação")]
+        public PublicacaoTipo Tipo { get; set; } = PublicacaoTipo.MensagemDireta;
+
         [Display(Name = "Assunto")]
         public string Assunto { get; set; } = string.Empty;
 
@@ -20,6 +23,23 @@ namespace Sistema.MVC.Models
 
         public IEnumerable<SelectListItem> Destinatarios { get; set; } = new List<SelectListItem>();
 
+        [Display(Name = "Setor")]
+        public int? PerfilId { get; set; }
+
+        public IEnumerable<SelectListItem> Perfis { get; set; } = new List<SelectListItem>();
+
+        [Display(Name = "Audiência do aviso")]
+        public AvisoAudiencia? AvisoAudiencia { get; set; }
+
+        [Display(Name = "Prioridade")]
+        public AvisoPrioridade? AvisoPrioridade { get; set; }
+
+        [Display(Name = "Válido até")]
+        public DateTime? AvisoValidoAte { get; set; }
+
+        [Display(Name = "Fixar no topo")]
+        public bool Fixada { get; set; }
+
         public bool ExibirCampoAssunto => !MensagemPaiId.HasValue;
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
@@ -29,9 +49,19 @@ namespace Sistema.MVC.Models
                 yield return new ValidationResult("Assunto é obrigatório", new[] { nameof(Assunto) });
             }
 
-            if (DestinatarioSelecionados is null || DestinatarioSelecionados.Count == 0)
+            if (Tipo == PublicacaoTipo.MensagemDireta && (DestinatarioSelecionados is null || DestinatarioSelecionados.Count == 0))
             {
                 yield return new ValidationResult("Selecione ao menos um destinatário ou setor.", new[] { nameof(DestinatarioSelecionados) });
+            }
+
+            if (Tipo == PublicacaoTipo.PostSetor && !PerfilId.HasValue)
+            {
+                yield return new ValidationResult("Selecione o setor para o post.", new[] { nameof(PerfilId) });
+            }
+
+            if (Tipo == PublicacaoTipo.Aviso && !AvisoAudiencia.HasValue)
+            {
+                yield return new ValidationResult("Selecione a audiência do aviso.", new[] { nameof(AvisoAudiencia) });
             }
         }
     }

--- a/0 - Apresentacao/Sistema.MVC/Program.cs
+++ b/0 - Apresentacao/Sistema.MVC/Program.cs
@@ -10,6 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 builder.Services.AddInfraestrutura(builder.Configuration);
 builder.Services.AddAplicacao();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession();
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
@@ -20,6 +21,20 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     });
 
 var app = builder.Build();
+
+app.Use(async (context, next) =>
+{
+    const string correlationHeader = "X-Correlation-ID";
+    var correlationId = context.Request.Headers[correlationHeader].FirstOrDefault();
+    if (string.IsNullOrWhiteSpace(correlationId))
+    {
+        correlationId = Guid.NewGuid().ToString("N");
+    }
+
+    context.TraceIdentifier = correlationId;
+    context.Response.Headers[correlationHeader] = correlationId;
+    await next();
+});
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/0 - Apresentacao/Sistema.MVC/Views/Documentacao/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Documentacao/Index.cshtml
@@ -10,6 +10,7 @@
             <li class="nav-item"><a class="nav-link" href="#configuracoes">Configurações</a></li>
             <li class="nav-item"><a class="nav-link" href="#tema">Tema</a></li>
             <li class="nav-item"><a class="nav-link" href="#mensagens">Mensagens</a></li>
+            <li class="nav-item"><a class="nav-link" href="#logs">Logs e auditoria</a></li>
             <li class="nav-item"><a class="nav-link" href="#scripts">Scripts</a></li>
         </ul>
     </nav>
@@ -25,6 +26,13 @@
         <section id="configuracoes">
             <h2>Configurações</h2>
             <p>Permite listar, criar e editar configurações agrupadas por tema.</p>
+            <p>Para política de retenção de logs, use o agrupamento <code>LogsRetencao</code> e as chaves:</p>
+            <ul>
+                <li><code>AcessoMeses</code> (padrão: 3)</li>
+                <li><code>ComunicacaoMeses</code> (padrão: 6)</li>
+                <li><code>AdministracaoMeses</code> (padrão: 12)</li>
+                <li><code>GeralMeses</code> (padrão: 12)</li>
+            </ul>
         </section>
         <section id="tema">
             <h2>Tema</h2>
@@ -42,6 +50,17 @@
                 <li><strong>Detalhes do remetente/destinatário:</strong> os nomes de quem enviou e de quem recebeu são sempre exibidos em cada linha.</li>
             </ul>
             <p>Para responder, use o botão de resposta na própria thread. O sistema preserva o contexto, garantindo que cada réplica apareça logo abaixo da anterior.</p>
+        </section>
+        <section id="logs">
+            <h2>Logs e auditoria</h2>
+            <p>A auditoria usa tabela única de logs com segmentação por módulo (<code>Acesso</code>, <code>Comunicacao</code>, <code>Administracao</code>).</p>
+            <ul>
+                <li><strong>Consulta por módulo:</strong> <code>/api/log/acesso</code>, <code>/api/log/comunicacao</code>, <code>/api/log/administracao</code>.</li>
+                <li><strong>Correlação:</strong> o cabeçalho <code>X-Correlation-ID</code> é propagado e salvo no log para rastrear a requisição de ponta a ponta.</li>
+                <li><strong>Retenção:</strong> aplicada automaticamente conforme configurações do agrupamento <code>LogsRetencao</code>.</li>
+                <li><strong>Fallback de escrita:</strong> quando o banco está indisponível, o sistema grava no arquivo interno <code>log-fallback/audit-fallback.ndjson</code>.</li>
+                <li><strong>Migração automática:</strong> ao restabelecer o banco, os itens do arquivo são inseridos no banco e removidos do fallback.</li>
+            </ul>
         </section>
         <section id="scripts">
             <h2>Scripts e interações</h2>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Detalhe.cshtml
@@ -6,13 +6,13 @@
 @await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
 {
     Title = Model.Assunto,
-    Description = "Detalhes da mensagem."
+    Description = "Thread social da comunicação interna."
 })
 
 <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <a href="@Url.Action("Index")" class="btn btn-outline-secondary btn-sm">&larr; Voltar</a>
-        <a href="@Url.Action("Nova", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })" class="btn btn-primary btn-sm">Responder à mensagem inicial</a>
+        <a href="@Url.Action("Index")" class="btn btn-outline-secondary btn-sm">&larr; Voltar ao feed</a>
+        <a href="@Url.Action("Nova", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })" class="btn btn-primary btn-sm">Responder</a>
     </div>
     <div class="card-body">
         @await Html.PartialAsync("_MensagemThread", Model)

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Index.cshtml
@@ -1,32 +1,52 @@
 @model Sistema.MVC.Models.MensagemViewModel
+@using Sistema.CORE.Entities
 @{
-    ViewData["Title"] = "Caixa de Entrada";
+    ViewData["Title"] = "Hub de Comunicação";
 }
 
 @await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
 {
-    Title = "Mensagens",
-    Description = "Visualize e gerencie suas mensagens."
+    Title = "Comunicação Interna",
+    Description = "Feed híbrido de mensagens diretas, posts de setor e avisos."
 })
 
 <form method="get" class="mb-3">
     <div class="card">
-        <div class="card-body">
-            <input type="text" name="palavraChave" class="form-control" placeholder="Buscar" value="@Model.PalavraChave" />
+        <div class="card-body row g-2">
+            <div class="col-md-4">
+                <input type="text" name="palavraChave" class="form-control" placeholder="Buscar" value="@Model.PalavraChave" />
+            </div>
+            <div class="col-md-2">
+                <select name="tipo" class="form-select" asp-items="Html.GetEnumSelectList<PublicacaoTipo>()">
+                    <option value="">Todos os tipos</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <select name="prioridadeMinima" class="form-select" asp-items="Html.GetEnumSelectList<AvisoPrioridade>()">
+                    <option value="">Qualquer prioridade</option>
+                </select>
+            </div>
+            <div class="col-md-2 form-check mt-2 ms-2">
+                <input class="form-check-input" type="checkbox" name="somenteNaoLidas" value="true" @(Model.SomenteNaoLidas ? "checked" : "") id="somenteNaoLidas" />
+                <label class="form-check-label" for="somenteNaoLidas">Não lidas</label>
+            </div>
         </div>
         <div class="card-footer text-end">
-            <button type="submit" class="btn btn-secondary">Buscar</button>
+            <button type="submit" class="btn btn-secondary">Filtrar</button>
         </div>
     </div>
 </form>
+
 <div class="card">
     <div class="card-body p-0">
         <table class="table mb-0">
             <thead>
                 <tr>
+                    <th>Tipo</th>
                     <th>Assunto</th>
-                    <th>Remetente</th>
+                    <th>Autor</th>
                     <th>Data</th>
+                    <th>Reações</th>
                     <th></th>
                 </tr>
             </thead>
@@ -34,9 +54,25 @@
             @foreach (var m in Model.Mensagens)
             {
                 <tr class="@(m.Lida ? "" : "fw-bold")">
-                    <td>@m.Assunto</td>
+                    <td>@m.Tipo</td>
+                    <td>
+                        @m.Assunto
+                        @if (m.Fixada)
+                        {
+                            <span class="badge bg-warning text-dark">Fixado</span>
+                        }
+                    </td>
                     <td>@m.RemetenteNome</td>
                     <td>@m.DataInclusao.ToLocalTime().ToString("g")</td>
+                    <td>
+                        @if (m.Reacoes?.Count > 0)
+                        {
+                            foreach (var r in m.Reacoes)
+                            {
+                                <span class="badge bg-light text-dark me-1">@r.Key: @r.Value</span>
+                            }
+                        }
+                    </td>
                     <td><a href="@Url.Action("Detalhe", new { id = m.Id })">Abrir</a></td>
                 </tr>
             }
@@ -45,6 +81,6 @@
     </div>
     <div class="card-footer text-end">
         <a href="@Url.Action("CaixaSaida")" class="btn btn-outline-secondary me-2">Caixa de saída</a>
-        <a href="@Url.Action("Nova")" class="btn btn-primary">Nova mensagem</a>
+        <a href="@Url.Action("Nova")" class="btn btn-primary">Nova publicação</a>
     </div>
 </div>

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/Nova.cshtml
@@ -1,12 +1,13 @@
 @model Sistema.MVC.Models.NovaMensagemViewModel
+@using Sistema.CORE.Entities
 @{
-    ViewData["Title"] = "Nova Mensagem";
+    ViewData["Title"] = "Nova Publicação";
 }
 
 @await Html.PartialAsync("_PageHeader", new PageHeaderViewModel
 {
-    Title = "Mensagens",
-    Description = "Envie uma nova mensagem."
+    Title = "Comunicação Interna",
+    Description = "Composer unificado para mensagem direta, post de setor e aviso."
 })
 
 <div class="card">
@@ -16,30 +17,47 @@
             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
             <input asp-for="MensagemPaiId" type="hidden" />
             <div class="mb-3">
-                <label asp-for="DestinatarioSelecionados" class="form-label"></label>
-                <select asp-for="DestinatarioSelecionados" class="form-select" asp-items="Model.Destinatarios" multiple>
-                    <option value="">Selecione destinatários</option>
-                </select>
-                <span asp-validation-for="DestinatarioSelecionados" class="text-danger"></span>
-                <span class="form-text">Escolha pessoas e/ou setores. Você pode selecionar mais de um.</span>
+                <label asp-for="Tipo" class="form-label"></label>
+                <select asp-for="Tipo" class="form-select" asp-items="Html.GetEnumSelectList<PublicacaoTipo>()"></select>
             </div>
-            @if (Model.ExibirCampoAssunto)
-            {
-                <div class="mb-3">
-                    <label asp-for="Assunto" class="form-label"></label>
-                    <input asp-for="Assunto" class="form-control" />
-                    <span asp-validation-for="Assunto" class="text-danger"></span>
+            <div class="mb-3 js-destinatarios">
+                <label asp-for="DestinatarioSelecionados" class="form-label"></label>
+                <select asp-for="DestinatarioSelecionados" class="form-select" asp-items="Model.Destinatarios" multiple></select>
+                <span asp-validation-for="DestinatarioSelecionados" class="text-danger"></span>
+            </div>
+            <div class="mb-3 js-perfil">
+                <label asp-for="PerfilId" class="form-label"></label>
+                <select asp-for="PerfilId" class="form-select" asp-items="Model.Perfis">
+                    <option value="">Selecione o setor</option>
+                </select>
+            </div>
+            <div class="row g-2 js-aviso">
+                <div class="col-md-4">
+                    <label asp-for="AvisoAudiencia" class="form-label"></label>
+                    <select asp-for="AvisoAudiencia" class="form-select" asp-items="Html.GetEnumSelectList<AvisoAudiencia>()">
+                        <option value="">Selecione</option>
+                    </select>
                 </div>
-            }
-            else
-            {
-                <input asp-for="Assunto" type="hidden" />
-                <div class="mb-3">
-                    <label class="form-label">Assunto da conversa</label>
-                    <input class="form-control" value="@Model.Assunto" readonly />
-                    <span class="form-text">Respostas mantêm o assunto da mensagem inicial.</span>
+                <div class="col-md-4">
+                    <label asp-for="AvisoPrioridade" class="form-label"></label>
+                    <select asp-for="AvisoPrioridade" class="form-select" asp-items="Html.GetEnumSelectList<AvisoPrioridade>()">
+                        <option value="">Selecione</option>
+                    </select>
                 </div>
-            }
+                <div class="col-md-4">
+                    <label asp-for="AvisoValidoAte" class="form-label"></label>
+                    <input asp-for="AvisoValidoAte" type="datetime-local" class="form-control" />
+                </div>
+                <div class="col-12 form-check mt-2 ms-2">
+                    <input asp-for="Fixada" class="form-check-input" />
+                    <label asp-for="Fixada" class="form-check-label"></label>
+                </div>
+            </div>
+            <div class="mb-3 mt-3">
+                <label asp-for="Assunto" class="form-label"></label>
+                <input asp-for="Assunto" class="form-control" />
+                <span asp-validation-for="Assunto" class="text-danger"></span>
+            </div>
             <div class="mb-3">
                 <label asp-for="Corpo" class="form-label"></label>
                 <textarea asp-for="Corpo" class="form-control" rows="5"></textarea>
@@ -48,21 +66,28 @@
         </div>
         <div class="card-footer d-flex justify-content-between">
             <a class="btn btn-outline-secondary" href="@Url.Action("Index")">Cancelar</a>
-            <button type="submit" class="btn btn-primary">Enviar</button>
+            <button type="submit" class="btn btn-primary">Publicar</button>
         </div>
     </form>
 </div>
 
 @section Scripts {
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script>
-        $(function () {
-            $('#DestinatarioSelecionados').select2({
-                placeholder: 'Selecione destinatários',
-                width: '100%',
-                closeOnSelect: false
-            });
-        });
+        (function() {
+            const tipoEl = document.getElementById('Tipo');
+            const destinos = document.querySelector('.js-destinatarios');
+            const perfil = document.querySelector('.js-perfil');
+            const aviso = document.querySelector('.js-aviso');
+
+            function refreshComposer() {
+                const tipo = Number(tipoEl.value || '1');
+                destinos.style.display = tipo === 1 ? 'block' : 'none';
+                perfil.style.display = (tipo === 2 || tipo === 3) ? 'block' : 'none';
+                aviso.style.display = tipo === 3 ? 'flex' : 'none';
+            }
+
+            tipoEl.addEventListener('change', refreshComposer);
+            refreshComposer();
+        })();
     </script>
 }

--- a/0 - Apresentacao/Sistema.MVC/Views/Mensagem/_MensagemThread.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Mensagem/_MensagemThread.cshtml
@@ -1,22 +1,44 @@
 @model Sistema.APP.DTOs.MensagemThreadDto
+@using Sistema.CORE.Entities
 
 <div class="mb-3">
     <div class="d-flex justify-content-between align-items-center">
         <div>
+            <span class="badge bg-info text-dark">@Model.Tipo</span>
             <strong>@Model.RemetenteNome</strong>
-            <span class="text-muted">para @Model.DestinatarioNome</span>
+            @if (!string.IsNullOrWhiteSpace(Model.PerfilNome))
+            {
+                <span class="text-muted">· @Model.PerfilNome</span>
+            }
         </div>
         <small class="text-muted">@Model.DataInclusao.ToLocalTime().ToString("g")</small>
     </div>
     <div class="mt-2">@Model.Corpo</div>
-    <div class="mt-2">
+
+    <div class="mt-2 d-flex gap-2 align-items-center flex-wrap">
         <a class="btn btn-sm btn-outline-primary" href="@Url.Action("Nova", "Mensagem", new { mensagemPaiId = Model.Id, destinatarioId = Model.RemetenteId })">Responder</a>
+
+        <form method="post" asp-action="Reagir" asp-controller="Mensagem" class="d-inline-flex gap-1">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="id" value="@Model.Id" />
+            <button class="btn btn-sm btn-outline-secondary" name="tipoReacao" value="@TipoReacao.Curtir">Curtir</button>
+            <button class="btn btn-sm btn-outline-secondary" name="tipoReacao" value="@TipoReacao.Aplaudir">Aplaudir</button>
+            <button class="btn btn-sm btn-outline-secondary" name="tipoReacao" value="@TipoReacao.Apoiar">Apoiar</button>
+        </form>
+
+        @if (Model.Reacoes?.Count > 0)
+        {
+            foreach (var reacao in Model.Reacoes)
+            {
+                <span class="badge bg-light text-dark">@reacao.Key: @reacao.Value</span>
+            }
+        }
     </div>
 </div>
 @if (Model.Respostas?.Any() == true)
 {
     <div class="ms-4 border-start ps-3">
-        @foreach (var resposta in Model.Respostas)
+        @foreach (var resposta in Model.Respostas.OrderBy(r => r.DataInclusao))
         {
             @await Html.PartialAsync("_MensagemThread", resposta)
         }

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -139,51 +139,57 @@
                             <small class="text-opacity-75">Bem-vindo(a)</small>
                         </div>
                     </li>
-                    <li class="nav-header text-uppercase small">Navegação</li>
+                    <li class="nav-header text-uppercase small">Módulos</li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Home", "Index")" asp-controller="Home" asp-action="Index" title="Início">
-                            <i class="bi bi-house me-2"></i><span>Home</span>
+                        <a class="nav-link @leftText @EstaAtivo("Home")" asp-controller="Home" asp-action="Index" title="Módulo Home">
+                            <i class="bi bi-house me-2"></i><span>Módulo Home</span>
                         </a>
+                        <ul>
+                            <li><a asp-controller="Home" asp-action="Index" title="Dashboard">Dashboard</a></li>
+                            <li><a asp-controller="Home" asp-action="Privacy" title="Privacidade">Privacidade</a></li>
+                        </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Home", "Privacy")" asp-controller="Home" asp-action="Privacy" title="Privacidade">
-                            <i class="bi bi-shield-lock me-2"></i><span>Privacy</span>
+                        <a class="nav-link @leftText @EstaAtivo("Account")" asp-controller="Account" asp-action="Login" title="Módulo Acesso">
+                            <i class="bi bi-shield-lock me-2"></i><span>Módulo Acesso</span>
                         </a>
+                        <ul>
+                            <li><a asp-controller="Account" asp-action="ChangePassword" title="Segurança">Segurança</a></li>
+                            <li><a href="/api/log/acesso" title="AcessoLog">AcessoLog (API)</a></li>
+                        </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Mensagem")" asp-controller="Mensagem" asp-action="Index" title="Mensagens">
-                            <i class="bi bi-envelope me-2"></i><span>Mensagens</span>
+                        <a class="nav-link @leftText @EstaAtivo("Mensagem")" asp-controller="Mensagem" asp-action="Index" title="Módulo Comunicação">
+                            <i class="bi bi-envelope me-2"></i><span>Módulo Comunicação</span>
                             @if (unreadMessages > 0)
                             {
                                 <span class="badge bg-primary ms-auto">@unreadMessages</span>
                             }
                         </a>
                         <ul>
-                            <li><a asp-controller="Mensagem" asp-action="Index" title="Caixa de entrada">Caixa de entrada</a></li>
+                            <li><a asp-controller="Mensagem" asp-action="Index" title="Feed">Feed</a></li>
                             <li><a asp-controller="Mensagem" asp-action="CaixaSaida" title="Caixa de saída">Caixa de saída</a></li>
+                            <li><a asp-controller="Mensagem" asp-action="Nova" title="Nova publicação">Nova publicação</a></li>
+                            <li><a href="/api/log/comunicacao" title="ComunicacaoLog">ComunicacaoLog (API)</a></li>
                         </ul>
                     </li>
-                    <li class="nav-header text-uppercase small">Personalização</li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Tema", "Edit")" asp-controller="Tema" asp-action="Edit" title="Tema">
-                            <i class="bi bi-palette me-2"></i><span>Tema</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Configuracao")" asp-controller="Configuracao" asp-action="Index" title="Configurações">
-                            <i class="bi bi-gear me-2"></i><span>Configurações</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Documentacao")" asp-controller="Documentacao" asp-action="Index" title="Documentação">
-                            <i class="bi bi-book me-2"></i><span>Documentação</span>
+                        <a class="nav-link @leftText @EstaAtivo("Configuracao")" asp-controller="Configuracao" asp-action="Index" title="Módulo Administração">
+                            <i class="bi bi-gear me-2"></i><span>Módulo Administração</span>
                         </a>
                         <ul>
-                            <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="login" title="Login">Login</a></li>
-                            <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="home" title="Página inicial">Página inicial</a></li>
-                            <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="configuracoes" title="Configurações">Configurações</a></li>
-                            <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="tema" title="Tema">Tema</a></li>
+                            <li><a asp-controller="Configuracao" asp-action="Index" title="Configurações">Configurações</a></li>
+                            <li><a asp-controller="Tema" asp-action="Edit" title="Tema">Tema</a></li>
+                            <li><a href="/api/log/administracao" title="AdministracaoLog">AdministracaoLog (API)</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @leftText @EstaAtivo("Documentacao")" asp-controller="Documentacao" asp-action="Index" title="Módulo Documentação">
+                            <i class="bi bi-book me-2"></i><span>Módulo Documentação</span>
+                        </a>
+                        <ul>
                             <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="mensagens" title="Mensagens">Mensagens</a></li>
+                            <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="logs" title="Logs e auditoria">Logs e auditoria</a></li>
                             <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="scripts" title="Scripts">Scripts</a></li>
                         </ul>
                     </li>

--- a/1 - Aplicacao/Sistema.APP/DTOs/FeedFiltroDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/FeedFiltroDto.cs
@@ -1,0 +1,12 @@
+using Sistema.CORE.Entities;
+
+namespace Sistema.APP.DTOs;
+
+public class FeedFiltroDto
+{
+    public PublicacaoTipo? Tipo { get; set; }
+    public int? PerfilId { get; set; }
+    public bool SomenteNaoLidas { get; set; }
+    public AvisoPrioridade? PrioridadeMinima { get; set; }
+    public string? PalavraChave { get; set; }
+}

--- a/1 - Aplicacao/Sistema.APP/DTOs/MensagemDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/MensagemDto.cs
@@ -1,19 +1,34 @@
 using System;
+using System.Collections.Generic;
+using Sistema.CORE.Entities;
 
 namespace Sistema.APP.DTOs
 {
     public class MensagemDto
     {
         public int Id { get; set; }
+        public PublicacaoTipo Tipo { get; set; }
+        public PublicacaoStatus Status { get; set; }
+        public int? AutorId { get; set; }
         public int? RemetenteId { get; set; }
         public string RemetenteNome { get; set; } = string.Empty;
-        public int DestinatarioId { get; set; }
+        public int? DestinatarioId { get; set; }
         public string DestinatarioNome { get; set; } = string.Empty;
+        public int? PerfilId { get; set; }
+        public string PerfilNome { get; set; } = string.Empty;
         public string Assunto { get; set; } = string.Empty;
         public string Corpo { get; set; } = string.Empty;
         public bool Lida { get; set; }
         public DateTime DataInclusao { get; set; }
         public DateTime? DataLeitura { get; set; }
         public int? MensagemPaiId { get; set; }
+        public AvisoAudiencia? AvisoAudiencia { get; set; }
+        public AvisoPrioridade? AvisoPrioridade { get; set; }
+        public DateTime? AvisoValidoAte { get; set; }
+        public bool Fixada { get; set; }
+        public Dictionary<TipoReacao, int> Reacoes { get; set; } = new();
+        public bool PodeResponder { get; set; }
+        public bool PodeReagir { get; set; }
+        public bool PodeModerar { get; set; }
     }
 }

--- a/1 - Aplicacao/Sistema.APP/DTOs/MensagemThreadDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/MensagemThreadDto.cs
@@ -1,21 +1,28 @@
 using System;
 using System.Collections.Generic;
+using Sistema.CORE.Entities;
 
 namespace Sistema.APP.DTOs
 {
     public class MensagemThreadDto
     {
         public int Id { get; set; }
+        public PublicacaoTipo Tipo { get; set; }
+        public PublicacaoStatus Status { get; set; }
+        public int? AutorId { get; set; }
         public int? RemetenteId { get; set; }
         public string RemetenteNome { get; set; } = string.Empty;
-        public int DestinatarioId { get; set; }
+        public int? DestinatarioId { get; set; }
         public string DestinatarioNome { get; set; } = string.Empty;
+        public int? PerfilId { get; set; }
+        public string PerfilNome { get; set; } = string.Empty;
         public string Assunto { get; set; } = string.Empty;
         public string Corpo { get; set; } = string.Empty;
         public bool Lida { get; set; }
         public DateTime DataInclusao { get; set; }
         public DateTime? DataLeitura { get; set; }
         public int? MensagemPaiId { get; set; }
+        public Dictionary<TipoReacao, int> Reacoes { get; set; } = new();
         public List<MensagemThreadDto> Respostas { get; set; } = new();
     }
 }

--- a/1 - Aplicacao/Sistema.APP/DTOs/NovaMensagemDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/NovaMensagemDto.cs
@@ -1,11 +1,19 @@
+using Sistema.CORE.Entities;
+
 namespace Sistema.APP.DTOs
 {
     public class NovaMensagemDto
     {
-        public int DestinatarioId { get; set; }
+        public PublicacaoTipo Tipo { get; set; } = PublicacaoTipo.MensagemDireta;
+        public int? DestinatarioId { get; set; }
+        public List<int> DestinatariosIds { get; set; } = new();
         public string Assunto { get; set; } = string.Empty;
         public string Corpo { get; set; } = string.Empty;
         public int? MensagemPaiId { get; set; }
         public int? PerfilId { get; set; }
+        public AvisoAudiencia? AvisoAudiencia { get; set; }
+        public AvisoPrioridade? AvisoPrioridade { get; set; }
+        public DateTime? AvisoValidoAte { get; set; }
+        public bool Fixada { get; set; }
     }
 }

--- a/1 - Aplicacao/Sistema.APP/DTOs/ReagirPublicacaoDto.cs
+++ b/1 - Aplicacao/Sistema.APP/DTOs/ReagirPublicacaoDto.cs
@@ -1,0 +1,8 @@
+using Sistema.CORE.Entities;
+
+namespace Sistema.APP.DTOs;
+
+public class ReagirPublicacaoDto
+{
+    public TipoReacao TipoReacao { get; set; }
+}

--- a/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
+++ b/1 - Aplicacao/Sistema.APP/Profiles/MappingProfile.cs
@@ -15,13 +15,24 @@ public class MappingProfile : Profile
             .ForMember(d => d.Ativo, o => o.MapFrom(s => s.Ativo))
             .ReverseMap();
         CreateMap<Configuracao, ConfiguracaoDto>().ReverseMap();
+
         CreateMap<Mensagem, MensagemDto>()
             .ForMember(d => d.RemetenteNome, o => o.MapFrom(s => s.Remetente != null ? s.Remetente.Nome : "Sistema"))
-            .ForMember(d => d.DestinatarioNome, o => o.MapFrom(s => s.Destinatario.Nome));
+            .ForMember(d => d.DestinatarioNome, o => o.MapFrom(s => s.Destinatario != null ? s.Destinatario.Nome : "Audiência"))
+            .ForMember(d => d.PerfilNome, o => o.MapFrom(s => s.Perfil != null ? s.Perfil.Nome : string.Empty))
+            .ForMember(d => d.Reacoes, o => o.MapFrom(s => s.Reacoes
+                .GroupBy(r => r.TipoReacao)
+                .ToDictionary(g => g.Key, g => g.Count())));
+
         CreateMap<Mensagem, MensagemThreadDto>()
             .ForMember(d => d.RemetenteNome, o => o.MapFrom(s => s.Remetente != null ? s.Remetente.Nome : "Sistema"))
-            .ForMember(d => d.DestinatarioNome, o => o.MapFrom(s => s.Destinatario.Nome))
+            .ForMember(d => d.DestinatarioNome, o => o.MapFrom(s => s.Destinatario != null ? s.Destinatario.Nome : "Audiência"))
+            .ForMember(d => d.PerfilNome, o => o.MapFrom(s => s.Perfil != null ? s.Perfil.Nome : string.Empty))
+            .ForMember(d => d.Reacoes, o => o.MapFrom(s => s.Reacoes
+                .GroupBy(r => r.TipoReacao)
+                .ToDictionary(g => g.Key, g => g.Count())))
             .ForMember(d => d.Respostas, o => o.MapFrom(s => s.Respostas));
+
         CreateMap<NovaMensagemDto, Mensagem>();
     }
 }

--- a/1 - Aplicacao/Sistema.APP/Services/AuthAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/AuthAppService.cs
@@ -11,18 +11,30 @@ using System.Text;
 
 namespace Sistema.APP.Services;
 
-public class AuthAppService(IUnitOfWork uow, IPasswordHasher<Usuario> hasher, IConfiguration config) : IAuthAppService
+public class AuthAppService(IUnitOfWork uow, IPasswordHasher<Usuario> hasher, IConfiguration config, ILogAppService log) : IAuthAppService
 {
     private readonly IUnitOfWork _uow = uow;
     private readonly IPasswordHasher<Usuario> _hasher = hasher;
     private readonly IConfiguration _config = config;
+    private readonly ILogAppService _log = log;
 
     public async Task<string?> AutenticarAsync(string cpf, string senha, CancellationToken cancellationToken = default)
     {
         var usuario = await _uow.Usuarios.BuscarPorCpfAsync(cpf, cancellationToken);
-        if (usuario is null || !usuario.Ativo) return null;
+        if (usuario is null || !usuario.Ativo)
+        {
+            await _log.RegistrarAcessoAsync(nameof(Usuario), "Login", false, "Tentativa de login inválida", LogTipo.Informacao, cpf, "Usuário não encontrado ou inativo", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
+            return null;
+        }
+
         var resultado = _hasher.VerifyHashedPassword(usuario, usuario.SenhaHash, senha);
-        if (resultado == PasswordVerificationResult.Failed) return null;
+        if (resultado == PasswordVerificationResult.Failed)
+        {
+            await _log.RegistrarAcessoAsync(nameof(Usuario), "Login", false, "Tentativa de login inválida", LogTipo.Informacao, usuario.Cpf, "Senha inválida", cancellationToken);
+            await _uow.ConfirmarAsync(cancellationToken);
+            return null;
+        }
 
         var reivindicacoes = new[]
         {
@@ -39,6 +51,9 @@ public class AuthAppService(IUnitOfWork uow, IPasswordHasher<Usuario> hasher, IC
             claims: reivindicacoes,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);
+
+        await _log.RegistrarAcessoAsync(nameof(Usuario), "Login", true, "Login realizado com sucesso", LogTipo.Sucesso, usuario.Cpf, null, cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
 
         return new JwtSecurityTokenHandler().WriteToken(token);
     }

--- a/1 - Aplicacao/Sistema.APP/Services/Interfaces/ILogAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/Interfaces/ILogAppService.cs
@@ -4,6 +4,15 @@ namespace Sistema.APP.Services.Interfaces;
 
 public interface ILogAppService
 {
-    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, LogModulo? modulo = null, CancellationToken cancellationToken = default);
     Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
+    Task RegistrarPorModuloAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, LogModulo modulo, string? detalhe = null, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Log>> BuscarAcessoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Log>> BuscarComunicacaoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Log>> BuscarAdministracaoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
+
+    Task RegistrarAcessoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
+    Task RegistrarComunicacaoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
+    Task RegistrarAdministracaoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default);
 }

--- a/1 - Aplicacao/Sistema.APP/Services/Interfaces/IMensagemAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/Interfaces/IMensagemAppService.cs
@@ -1,3 +1,4 @@
+using Sistema.APP.DTOs;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 
@@ -7,10 +8,13 @@ public interface IMensagemAppService
 {
     Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null, CancellationToken cancellationToken = default);
     Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<Mensagem>> BuscarFeedAsync(int usuarioId, int page, int pageSize, FeedFiltroDto? filtro = null, CancellationToken cancellationToken = default);
     Task<Mensagem?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);
     Task<Mensagem?> BuscarConversaAsync(int mensagemId, int usuarioId, CancellationToken cancellationToken = default);
     Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default);
     Task<OperationResult<List<int>>> EnviarParaPerfilAsync(int? remetenteId, int perfilId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default);
+    Task<OperationResult<int>> CriarPublicacaoAsync(int autorId, NovaMensagemDto dto, CancellationToken cancellationToken = default);
     Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId, CancellationToken cancellationToken = default);
+    Task<OperationResult> ReagirAsync(int publicacaoId, int usuarioId, TipoReacao tipoReacao, CancellationToken cancellationToken = default);
     Task<int> ContarNaoLidasAsync(int usuarioId, CancellationToken cancellationToken = default);
 }

--- a/1 - Aplicacao/Sistema.APP/Services/LogAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/LogAppService.cs
@@ -1,19 +1,48 @@
+using Microsoft.AspNetCore.Http;
 using Sistema.APP.Services.Interfaces;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Repositories.Interfaces;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
 
 namespace Sistema.APP.Services;
 
-public class LogAppService(IUnitOfWork uow) : ILogAppService
+public class LogAppService(IUnitOfWork uow, IHttpContextAccessor httpContextAccessor) : ILogAppService
 {
-    private readonly IUnitOfWork _uow = uow;
+    private const string AgrupamentoRetencaoLogs = "LogsRetencao";
+    private const string ChaveAcessoMeses = "AcessoMeses";
+    private const string ChaveComunicacaoMeses = "ComunicacaoMeses";
+    private const string ChaveAdministracaoMeses = "AdministracaoMeses";
+    private const string ChaveGeralMeses = "GeralMeses";
+    private static readonly string FallbackDirectory = Path.Combine(AppContext.BaseDirectory, "log-fallback");
+    private static readonly string FallbackFilePath = Path.Combine(FallbackDirectory, "audit-fallback.ndjson");
 
-    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
-        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, cancellationToken);
+    private readonly IUnitOfWork _uow = uow;
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+
+    public Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, LogModulo? modulo = null, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, modulo, cancellationToken);
+
+    public Task<IEnumerable<Log>> BuscarAcessoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, LogModulo.Acesso, cancellationToken);
+
+    public Task<IEnumerable<Log>> BuscarComunicacaoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, LogModulo.Comunicacao, cancellationToken);
+
+    public Task<IEnumerable<Log>> BuscarAdministracaoAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+        => _uow.Logs.BuscarFiltradosAsync(inicio, fim, tipo, LogModulo.Administracao, cancellationToken);
 
     public Task RegistrarAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
+        => RegistrarPorModuloAsync(entidade, operacao, sucesso, mensagem, tipo, usuario, LogModulo.Administracao, detalhe, cancellationToken);
+
+    public async Task RegistrarPorModuloAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, LogModulo modulo, string? detalhe = null, CancellationToken cancellationToken = default)
     {
-        return _uow.Logs.AdicionarAsync(new Log
+        var contexto = _httpContextAccessor.HttpContext;
+        var correlationId = contexto?.Request.Headers["X-Correlation-ID"].FirstOrDefault();
+        correlationId ??= contexto?.TraceIdentifier;
+
+        var log = new Log
         {
             Entidade = entidade,
             Operacao = operacao,
@@ -21,7 +50,111 @@ public class LogAppService(IUnitOfWork uow) : ILogAppService
             Mensagem = mensagem,
             Tipo = tipo,
             Usuario = usuario,
-            Detalhe = detalhe
-        }, cancellationToken);
+            Detalhe = detalhe,
+            Modulo = modulo,
+            CorrelationId = correlationId,
+            TraceId = Activity.Current?.TraceId.ToString(),
+            SpanId = Activity.Current?.SpanId.ToString(),
+            DataOperacao = DateTime.UtcNow
+        };
+
+        try
+        {
+            await _uow.Logs.AdicionarAsync(log, cancellationToken);
+            await MigrarFallbackParaBancoAsync(cancellationToken);
+            await AplicarPoliticaRetencaoAsync(cancellationToken);
+        }
+        catch
+        {
+            await GravarFallbackAsync(log, cancellationToken);
+        }
+    }
+
+    public Task RegistrarAcessoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
+        => RegistrarPorModuloAsync(entidade, operacao, sucesso, mensagem, tipo, usuario, LogModulo.Acesso, detalhe, cancellationToken);
+
+    public Task RegistrarComunicacaoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
+        => RegistrarPorModuloAsync(entidade, operacao, sucesso, mensagem, tipo, usuario, LogModulo.Comunicacao, detalhe, cancellationToken);
+
+    public Task RegistrarAdministracaoAsync(string entidade, string operacao, bool sucesso, string mensagem, LogTipo tipo, string usuario, string? detalhe = null, CancellationToken cancellationToken = default)
+        => RegistrarPorModuloAsync(entidade, operacao, sucesso, mensagem, tipo, usuario, LogModulo.Administracao, detalhe, cancellationToken);
+
+    private async Task AplicarPoliticaRetencaoAsync(CancellationToken cancellationToken)
+    {
+        var mesesAcesso = await ObterMesesRetencaoAsync(ChaveAcessoMeses, 3, cancellationToken);
+        var mesesComunicacao = await ObterMesesRetencaoAsync(ChaveComunicacaoMeses, 6, cancellationToken);
+        var mesesAdministracao = await ObterMesesRetencaoAsync(ChaveAdministracaoMeses, 12, cancellationToken);
+        var mesesGeral = await ObterMesesRetencaoAsync(ChaveGeralMeses, 12, cancellationToken);
+
+        await _uow.Logs.RemoverAntesDeAsync(LogModulo.Acesso, DateTime.UtcNow.AddMonths(-mesesAcesso), cancellationToken);
+        await _uow.Logs.RemoverAntesDeAsync(LogModulo.Comunicacao, DateTime.UtcNow.AddMonths(-mesesComunicacao), cancellationToken);
+        await _uow.Logs.RemoverAntesDeAsync(LogModulo.Administracao, DateTime.UtcNow.AddMonths(-mesesAdministracao), cancellationToken);
+        await _uow.Logs.RemoverAntesDeAsync(LogModulo.Geral, DateTime.UtcNow.AddMonths(-mesesGeral), cancellationToken);
+    }
+
+    private async Task<int> ObterMesesRetencaoAsync(string chave, int padrao, CancellationToken cancellationToken)
+    {
+        var config = await _uow.Configuracoes.BuscarPorChaveAsync(AgrupamentoRetencaoLogs, chave, cancellationToken);
+        if (config is null || string.IsNullOrWhiteSpace(config.Valor))
+            return padrao;
+
+        return int.TryParse(config.Valor, NumberStyles.Integer, CultureInfo.InvariantCulture, out var meses) && meses > 0
+            ? meses
+            : padrao;
+    }
+
+    private static async Task GravarFallbackAsync(Log log, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(FallbackDirectory);
+        var linha = JsonSerializer.Serialize(log);
+        await File.AppendAllTextAsync(FallbackFilePath, linha + Environment.NewLine, cancellationToken);
+    }
+
+    private async Task MigrarFallbackParaBancoAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(FallbackFilePath))
+            return;
+
+        var linhas = await File.ReadAllLinesAsync(FallbackFilePath, cancellationToken);
+        if (linhas.Length == 0)
+            return;
+
+        var registrosValidos = new List<Log>();
+        var linhasInvalidas = new List<string>();
+
+        foreach (var linha in linhas)
+        {
+            if (string.IsNullOrWhiteSpace(linha))
+                continue;
+
+            try
+            {
+                var item = JsonSerializer.Deserialize<Log>(linha);
+                if (item is not null)
+                {
+                    if (item.DataOperacao == default)
+                        item.DataOperacao = DateTime.UtcNow;
+                    registrosValidos.Add(item);
+                }
+            }
+            catch
+            {
+                linhasInvalidas.Add(linha);
+            }
+        }
+
+        if (registrosValidos.Count != 0)
+        {
+            await _uow.Logs.AdicionarEmLoteAsync(registrosValidos, cancellationToken);
+        }
+
+        if (linhasInvalidas.Count == 0)
+        {
+            File.Delete(FallbackFilePath);
+        }
+        else
+        {
+            await File.WriteAllLinesAsync(FallbackFilePath, linhasInvalidas, cancellationToken);
+        }
     }
 }

--- a/1 - Aplicacao/Sistema.APP/Services/MensagemAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/MensagemAppService.cs
@@ -1,14 +1,17 @@
 using Microsoft.EntityFrameworkCore;
+using Sistema.APP.DTOs;
 using Sistema.APP.Services.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Repositories.Interfaces;
+using System.Globalization;
 
 namespace Sistema.APP.Services;
 
-public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
+public class MensagemAppService(IUnitOfWork uow, ILogAppService logService) : IMensagemAppService
 {
     private readonly IUnitOfWork _uow = uow;
+    private readonly ILogAppService _logService = logService;
 
     private static OperationResult<int> ValidarConteudo(string assunto, string corpo)
     {
@@ -24,11 +27,58 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
         return new OperationResult<int>(true, string.Empty);
     }
 
+    private static bool EhChefeSetor(Usuario usuario) =>
+        usuario.Perfil?.Nome?.Contains("chefe", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool EhAdmin(Usuario usuario) =>
+        usuario.Perfil?.Nome?.Contains("admin", StringComparison.OrdinalIgnoreCase) == true;
+
+    private async Task<OperationResult<Usuario>> ObterAutorAsync(int usuarioId, CancellationToken cancellationToken)
+    {
+        var usuario = await _uow.Usuarios.Query().Include(u => u.Perfil).FirstOrDefaultAsync(u => u.Id == usuarioId, cancellationToken);
+        if (usuario is null)
+            return new OperationResult<Usuario>(false, "Usuário não encontrado.");
+
+        return new OperationResult<Usuario>(true, string.Empty, usuario);
+    }
+
+    public async Task<PagedResult<Mensagem>> BuscarFeedAsync(int usuarioId, int page, int pageSize, FeedFiltroDto? filtro = null, CancellationToken cancellationToken = default)
+    {
+        IQueryable<Mensagem> query = _uow.Mensagens.Query()
+            .Where(m => m.Status == PublicacaoStatus.Ativa)
+            .Where(m =>
+                (m.Tipo == PublicacaoTipo.MensagemDireta && (m.DestinatarioId == usuarioId || m.RemetenteId == usuarioId)) ||
+                (m.Tipo == PublicacaoTipo.PostSetor && (!m.PerfilId.HasValue || _uow.Usuarios.Query().Where(u => u.Id == usuarioId).Select(u => u.PerfilId).Contains(m.PerfilId.Value))) ||
+                (m.Tipo == PublicacaoTipo.Aviso &&
+                    (m.AvisoAudiencia == AvisoAudiencia.Todos
+                     || (m.AvisoAudiencia == AvisoAudiencia.Setor && m.PerfilId.HasValue && _uow.Usuarios.Query().Where(u => u.Id == usuarioId).Select(u => u.PerfilId).Contains(m.PerfilId.Value))
+                     || (m.AvisoAudiencia == AvisoAudiencia.Usuarios && (m.DestinatarioId == usuarioId || m.DestinatariosExplicitos.Any(d => d.UsuarioId == usuarioId)))
+                     || (m.AvisoAudiencia == AvisoAudiencia.Grupo && m.AvisoGrupo != null))));
+
+        if (filtro?.Tipo is not null)
+            query = query.Where(m => m.Tipo == filtro.Tipo.Value);
+        if (filtro?.PerfilId is not null)
+            query = query.Where(m => m.PerfilId == filtro.PerfilId.Value);
+        if (!string.IsNullOrWhiteSpace(filtro?.PalavraChave))
+            query = query.Where(m => m.Assunto.Contains(filtro.PalavraChave) || m.Corpo.Contains(filtro.PalavraChave));
+        if (filtro?.PrioridadeMinima is not null)
+            query = query.Where(m => m.AvisoPrioridade == null || m.AvisoPrioridade >= filtro.PrioridadeMinima.Value);
+        if (filtro?.SomenteNaoLidas == true)
+            query = query.Where(m => !m.Leituras.Any(l => l.UsuarioId == usuarioId));
+
+        query = query.Where(m => !m.AvisoValidoAte.HasValue || m.AvisoValidoAte >= DateTime.UtcNow)
+                     .OrderByDescending(m => m.Fixada)
+                     .ThenByDescending(m => m.DataInclusao);
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
+        return new PagedResult<Mensagem>(items, total, page, pageSize);
+    }
+
     public async Task<PagedResult<Mensagem>> BuscarCaixaEntradaAsync(int usuarioId, int page, int pageSize, int? remetenteId = null, string? palavraChave = null, DateTime? inicio = null, DateTime? fim = null, CancellationToken cancellationToken = default)
     {
         IQueryable<Mensagem> query = _uow.Mensagens.Query()
-            .Include(m => m.Remetente)
-            .Include(m => m.Destinatario)
+            .Where(m => m.Tipo == PublicacaoTipo.MensagemDireta)
             .Where(m => m.DestinatarioId == usuarioId);
 
         if (remetenteId.HasValue)
@@ -50,8 +100,7 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
     public async Task<PagedResult<Mensagem>> BuscarCaixaSaidaAsync(int usuarioId, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var query = _uow.Mensagens.Query()
-            .Include(m => m.Remetente)
-            .Include(m => m.Destinatario)
+            .Where(m => m.Tipo == PublicacaoTipo.MensagemDireta)
             .Where(m => m.RemetenteId == usuarioId)
             .OrderByDescending(m => m.DataInclusao);
         var total = await query.CountAsync(cancellationToken);
@@ -63,24 +112,22 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
 
     public async Task<Mensagem?> BuscarConversaAsync(int mensagemId, int usuarioId, CancellationToken cancellationToken = default)
     {
-        var baseQuery = _uow.Mensagens.Query()
-            .Include(m => m.Remetente)
-            .Include(m => m.Destinatario);
+        var baseQuery = _uow.Mensagens.Query();
 
-        var mensagem = await baseQuery
-            .FirstOrDefaultAsync(m => m.Id == mensagemId, cancellationToken);
-        if (mensagem is null || (mensagem.RemetenteId != usuarioId && mensagem.DestinatarioId != usuarioId))
+        var mensagem = await baseQuery.FirstOrDefaultAsync(m => m.Id == mensagemId, cancellationToken);
+        if (mensagem is null)
+            return null;
+
+        var podeVer = await PodeVisualizarAsync(mensagem, usuarioId, cancellationToken);
+        if (!podeVer)
             return null;
 
         var raiz = mensagem;
         while (raiz.MensagemPaiId.HasValue)
         {
-            var pai = await baseQuery
-                .FirstOrDefaultAsync(m => m.Id == raiz.MensagemPaiId.Value, cancellationToken);
+            var pai = await baseQuery.FirstOrDefaultAsync(m => m.Id == raiz.MensagemPaiId.Value, cancellationToken);
             if (pai is null)
                 break;
-            if (pai.RemetenteId != usuarioId && pai.DestinatarioId != usuarioId)
-                return null;
             raiz = pai;
         }
 
@@ -91,13 +138,21 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
         {
             var filhos = await baseQuery
                 .Where(m => m.MensagemPaiId.HasValue && fronteira.Contains(m.MensagemPaiId.Value))
-                .Where(m => m.RemetenteId == usuarioId || m.DestinatarioId == usuarioId)
                 .OrderBy(m => m.DataInclusao)
                 .ToListAsync(cancellationToken);
 
             if (filhos.Count == 0) break;
 
-            todas.AddRange(filhos);
+            var filhosVisiveis = new List<Mensagem>();
+            foreach (var filho in filhos)
+            {
+                if (await PodeVisualizarAsync(filho, usuarioId, cancellationToken))
+                {
+                    filhosVisiveis.Add(filho);
+                }
+            }
+
+            todas.AddRange(filhosVisiveis);
             fronteira = [.. filhos.Select(f => f.Id)];
         }
 
@@ -108,6 +163,112 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
         }
 
         return raiz;
+    }
+
+    private async Task<bool> PodeVisualizarAsync(Mensagem mensagem, int usuarioId, CancellationToken cancellationToken)
+    {
+        if (mensagem.Tipo == PublicacaoTipo.MensagemDireta)
+            return mensagem.RemetenteId == usuarioId || mensagem.DestinatarioId == usuarioId || mensagem.DestinatariosExplicitos.Any(d => d.UsuarioId == usuarioId);
+
+        if (mensagem.Tipo == PublicacaoTipo.PostSetor)
+        {
+            if (!mensagem.PerfilId.HasValue) return true;
+            var perfilUsuario = await _uow.Usuarios.Query().Where(u => u.Id == usuarioId).Select(u => u.PerfilId).FirstOrDefaultAsync(cancellationToken);
+            return perfilUsuario == mensagem.PerfilId;
+        }
+
+        if (mensagem.Tipo == PublicacaoTipo.Aviso)
+        {
+            return mensagem.AvisoAudiencia switch
+            {
+                AvisoAudiencia.Todos => true,
+                AvisoAudiencia.Setor => (await _uow.Usuarios.Query().Where(u => u.Id == usuarioId).Select(u => u.PerfilId).FirstOrDefaultAsync(cancellationToken)) == mensagem.PerfilId,
+                AvisoAudiencia.Usuarios => mensagem.DestinatarioId == usuarioId || mensagem.DestinatariosExplicitos.Any(d => d.UsuarioId == usuarioId),
+                _ => true
+            };
+        }
+
+        return false;
+    }
+
+    public async Task<OperationResult<int>> CriarPublicacaoAsync(int autorId, NovaMensagemDto dto, CancellationToken cancellationToken = default)
+    {
+        var autorResult = await ObterAutorAsync(autorId, cancellationToken);
+        if (!autorResult.Success || autorResult.Data is null)
+            return new OperationResult<int>(false, autorResult.Message);
+
+        var autor = autorResult.Data;
+        var validacao = ValidarConteudo(dto.Assunto, dto.Corpo);
+        if (!validacao.Success)
+            return validacao;
+
+        if (dto.Tipo == PublicacaoTipo.MensagemDireta)
+        {
+            if (!dto.DestinatarioId.HasValue)
+                return new OperationResult<int>(false, "Destinatário é obrigatório para mensagem direta.");
+
+            return await EnviarAsync(autorId, dto.DestinatarioId.Value, dto.Assunto, dto.Corpo, dto.MensagemPaiId, cancellationToken);
+        }
+
+        if (dto.Tipo == PublicacaoTipo.PostSetor)
+        {
+            if (!EhChefeSetor(autor) && !EhAdmin(autor))
+                return new OperationResult<int>(false, "Somente chefes de setor ou admin podem publicar posts de setor.");
+
+            if (!dto.PerfilId.HasValue)
+                return new OperationResult<int>(false, "Perfil/setor é obrigatório para post de setor.");
+
+            if (!EhAdmin(autor) && autor.PerfilId != dto.PerfilId)
+                return new OperationResult<int>(false, "Chefe de setor só pode publicar no próprio setor.");
+        }
+
+        if (dto.Tipo == PublicacaoTipo.Aviso)
+        {
+            if (dto.AvisoAudiencia == AvisoAudiencia.Todos && !EhAdmin(autor))
+                return new OperationResult<int>(false, "Apenas admin/sistema pode publicar aviso global.");
+
+            if (!EhAdmin(autor) && !EhChefeSetor(autor))
+                return new OperationResult<int>(false, "Sem permissão para publicar aviso.");
+
+            if (!EhAdmin(autor) && dto.AvisoAudiencia == AvisoAudiencia.Setor && dto.PerfilId != autor.PerfilId)
+                return new OperationResult<int>(false, "Chefe de setor só pode publicar avisos para seu setor.");
+        }
+
+        var publicacao = new Mensagem
+        {
+            Tipo = dto.Tipo,
+            Status = PublicacaoStatus.Ativa,
+            AutorId = autorId,
+            RemetenteId = autorId,
+            DestinatarioId = dto.DestinatarioId,
+            PerfilId = dto.PerfilId,
+            Assunto = dto.Assunto.Trim(),
+            Corpo = dto.Corpo.Trim(),
+            MensagemPaiId = dto.MensagemPaiId,
+            Lida = false,
+            AvisoAudiencia = dto.AvisoAudiencia,
+            AvisoPrioridade = dto.AvisoPrioridade,
+            AvisoValidoAte = dto.AvisoValidoAte,
+            Fixada = dto.Fixada
+        };
+
+        await _uow.Mensagens.AddAsync(publicacao, cancellationToken);
+
+        if (dto.DestinatariosIds.Count != 0)
+        {
+            foreach (var usuarioId in dto.DestinatariosIds.Distinct())
+            {
+                publicacao.DestinatariosExplicitos.Add(new MensagemDestinatario
+                {
+                    UsuarioId = usuarioId,
+                    Mensagem = publicacao
+                });
+            }
+        }
+
+        await _logService.RegistrarComunicacaoAsync(nameof(Mensagem), "CriarPublicacao", true, $"Publicação {dto.Tipo} criada", LogTipo.Sucesso, autorId.ToString(CultureInfo.InvariantCulture), $"PublicacaoId={publicacao.Id}", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
+        return new OperationResult<int>(true, string.Empty, publicacao.Id);
     }
 
     public async Task<OperationResult<int>> EnviarAsync(int? remetenteId, int destinatarioId, string assunto, string corpo, int? mensagemPaiId = null, CancellationToken cancellationToken = default)
@@ -132,6 +293,9 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
 
         var msg = new Mensagem
         {
+            Tipo = PublicacaoTipo.MensagemDireta,
+            Status = PublicacaoStatus.Ativa,
+            AutorId = remetenteId,
             RemetenteId = remetenteId,
             DestinatarioId = destinatarioId,
             Assunto = assuntoLimpo,
@@ -140,6 +304,7 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
             Lida = false
         };
         await _uow.Mensagens.AddAsync(msg, cancellationToken);
+        await _logService.RegistrarComunicacaoAsync(nameof(Mensagem), "EnviarDireta", true, "Mensagem direta enviada", LogTipo.Sucesso, (remetenteId ?? 0).ToString(CultureInfo.InvariantCulture), $"MensagemId={msg.Id};Destinatario={destinatarioId}", cancellationToken);
         await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult<int>(true, string.Empty, msg.Id);
     }
@@ -164,44 +329,94 @@ public class MensagemAppService(IUnitOfWork uow) : IMensagemAppService
                 return new OperationResult<List<int>>(false, "Remetente não encontrado");
         }
 
-        var ids = new List<int>();
-        foreach (var destinatario in usuarios)
+        var mensagens = usuarios.Select(destinatario => new Mensagem
         {
-            var msg = new Mensagem
+            Tipo = PublicacaoTipo.MensagemDireta,
+            Status = PublicacaoStatus.Ativa,
+            AutorId = remetenteId,
+            RemetenteId = remetenteId,
+            DestinatarioId = destinatario.Id,
+            PerfilId = perfilId,
+            Assunto = assuntoLimpo,
+            Corpo = corpoLimpo,
+            MensagemPaiId = mensagemPaiId,
+            Lida = false
+        }).ToList();
+
+        await _uow.Mensagens.AddRangeAsync(mensagens, cancellationToken);
+        await _logService.RegistrarComunicacaoAsync(nameof(Mensagem), "EnviarParaPerfil", true, "Mensagens enviadas para setor", LogTipo.Sucesso, (remetenteId ?? 0).ToString(CultureInfo.InvariantCulture), $"PerfilId={perfilId};Quantidade={mensagens.Count}", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
+
+        return new OperationResult<List<int>>(true, string.Empty, mensagens.Select(m => m.Id).ToList());
+    }
+
+    public async Task<OperationResult> ReagirAsync(int publicacaoId, int usuarioId, TipoReacao tipoReacao, CancellationToken cancellationToken = default)
+    {
+        var publicacao = await _uow.Mensagens.GetByIdAsync(publicacaoId, cancellationToken);
+        if (publicacao is null)
+            return new OperationResult(false, "Publicação não encontrada.");
+
+        if (!await PodeVisualizarAsync(publicacao, usuarioId, cancellationToken))
+            return new OperationResult(false, "Usuário sem permissão para reagir a esta publicação.");
+
+        var reacaoAtual = await _uow.Mensagens.QueryReacoes().FirstOrDefaultAsync(r => r.PublicacaoId == publicacaoId && r.UsuarioId == usuarioId, cancellationToken);
+        if (reacaoAtual is null)
+        {
+            await _uow.Mensagens.AddReacaoAsync(new MensagemReacao
             {
-                RemetenteId = remetenteId,
-                DestinatarioId = destinatario.Id,
-                Assunto = assuntoLimpo,
-                Corpo = corpoLimpo,
-                MensagemPaiId = mensagemPaiId,
-                Lida = false
-            };
-            await _uow.Mensagens.AddAsync(msg, cancellationToken);
-            ids.Add(msg.Id);
+                PublicacaoId = publicacaoId,
+                UsuarioId = usuarioId,
+                TipoReacao = tipoReacao,
+                Data = DateTime.UtcNow
+            }, cancellationToken);
+        }
+        else
+        {
+            reacaoAtual.TipoReacao = tipoReacao;
+            reacaoAtual.Data = DateTime.UtcNow;
+            _uow.Mensagens.UpdateReacao(reacaoAtual);
         }
 
+        await _logService.RegistrarComunicacaoAsync(nameof(Mensagem), "Reagir", true, "Reação registrada", LogTipo.Sucesso, usuarioId.ToString(CultureInfo.InvariantCulture), $"PublicacaoId={publicacaoId};Reacao={tipoReacao}", cancellationToken);
         await _uow.ConfirmarAsync(cancellationToken);
-        return new OperationResult<List<int>>(true, string.Empty, ids);
+        return new OperationResult(true, string.Empty);
     }
 
     public async Task<OperationResult> MarcarComoLidaAsync(int id, int usuarioId, CancellationToken cancellationToken = default)
     {
         var msg = await _uow.Mensagens.GetByIdAsync(id, cancellationToken);
-        if (msg == null || msg.DestinatarioId != usuarioId)
+        if (msg == null || !await PodeVisualizarAsync(msg, usuarioId, cancellationToken))
             return new OperationResult(false, "Mensagem não encontrada");
-        if (!msg.Lida)
+
+        var leituraJaExiste = await _uow.Mensagens.QueryLeituras().AnyAsync(l => l.PublicacaoId == id && l.UsuarioId == usuarioId, cancellationToken);
+        if (!leituraJaExiste)
+        {
+            await _uow.Mensagens.AddLeituraAsync(new MensagemLeitura
+            {
+                PublicacaoId = id,
+                UsuarioId = usuarioId,
+                DataLeitura = DateTime.UtcNow,
+                DataEntrega = msg.DataInclusao
+            }, cancellationToken);
+        }
+
+        if (msg.DestinatarioId == usuarioId && !msg.Lida)
         {
             msg.Lida = true;
             msg.DataLeitura = DateTime.UtcNow;
             _uow.Mensagens.Update(msg);
-            await _uow.ConfirmarAsync(cancellationToken);
         }
+
+        await _logService.RegistrarComunicacaoAsync(nameof(Mensagem), "MarcarLida", true, "Publicação marcada como lida", LogTipo.Sucesso, usuarioId.ToString(CultureInfo.InvariantCulture), $"PublicacaoId={id}", cancellationToken);
+        await _uow.ConfirmarAsync(cancellationToken);
         return new OperationResult(true, string.Empty);
     }
 
     public async Task<int> ContarNaoLidasAsync(int usuarioId, CancellationToken cancellationToken = default)
     {
-        var total = await _uow.Mensagens.Query().CountAsync(m => m.DestinatarioId == usuarioId && !m.Lida, cancellationToken);
+        var total = await _uow.Mensagens.Query().CountAsync(m =>
+            (m.DestinatarioId == usuarioId || m.DestinatariosExplicitos.Any(d => d.UsuarioId == usuarioId)) &&
+            !m.Leituras.Any(l => l.UsuarioId == usuarioId), cancellationToken);
         return total;
     }
 }

--- a/1 - Aplicacao/Sistema.APP/Sistema.APP.csproj
+++ b/1 - Aplicacao/Sistema.APP/Sistema.APP.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/2 - Dominio/Sistema.CORE/Entities/Log.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Log.cs
@@ -9,6 +9,10 @@ public class Log
     public bool Sucesso { get; set; }
     public string Mensagem { get; set; } = string.Empty;
     public LogTipo Tipo { get; set; }
+    public LogModulo Modulo { get; set; } = LogModulo.Geral;
     public string Usuario { get; set; } = string.Empty;
+    public string? CorrelationId { get; set; }
+    public string? TraceId { get; set; }
+    public string? SpanId { get; set; }
     public string? Detalhe { get; set; }
 }

--- a/2 - Dominio/Sistema.CORE/Entities/LogModulo.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/LogModulo.cs
@@ -1,0 +1,9 @@
+namespace Sistema.CORE.Entities;
+
+public enum LogModulo
+{
+    Geral = 0,
+    Acesso = 1,
+    Comunicacao = 2,
+    Administracao = 3
+}

--- a/2 - Dominio/Sistema.CORE/Entities/Mensagem.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/Mensagem.cs
@@ -5,10 +5,16 @@ namespace Sistema.CORE.Entities
     public class Mensagem : AuditableEntity
     {
         public int Id { get; set; }
+        public PublicacaoTipo Tipo { get; set; } = PublicacaoTipo.MensagemDireta;
+        public PublicacaoStatus Status { get; set; } = PublicacaoStatus.Ativa;
+        public int? AutorId { get; set; }
+        public Usuario? Autor { get; set; }
         public int? RemetenteId { get; set; }
         public Usuario? Remetente { get; set; }
-        public int DestinatarioId { get; set; }
-        public Usuario Destinatario { get; set; } = null!;
+        public int? DestinatarioId { get; set; }
+        public Usuario? Destinatario { get; set; }
+        public int? PerfilId { get; set; }
+        public Perfil? Perfil { get; set; }
         public string Assunto { get; set; } = string.Empty;
         public string Corpo { get; set; } = string.Empty;
         public bool Lida { get; set; }
@@ -16,5 +22,15 @@ namespace Sistema.CORE.Entities
         public int? MensagemPaiId { get; set; }
         public Mensagem? MensagemPai { get; set; }
         public List<Mensagem> Respostas { get; set; } = new();
+
+        public AvisoAudiencia? AvisoAudiencia { get; set; }
+        public AvisoPrioridade? AvisoPrioridade { get; set; }
+        public DateTime? AvisoValidoAte { get; set; }
+        public bool Fixada { get; set; }
+        public string? AvisoGrupo { get; set; }
+
+        public List<MensagemDestinatario> DestinatariosExplicitos { get; set; } = new();
+        public List<MensagemReacao> Reacoes { get; set; } = new();
+        public List<MensagemLeitura> Leituras { get; set; } = new();
     }
 }

--- a/2 - Dominio/Sistema.CORE/Entities/MensagemDestinatario.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/MensagemDestinatario.cs
@@ -1,0 +1,9 @@
+namespace Sistema.CORE.Entities;
+
+public class MensagemDestinatario
+{
+    public int MensagemId { get; set; }
+    public Mensagem Mensagem { get; set; } = null!;
+    public int UsuarioId { get; set; }
+    public Usuario Usuario { get; set; } = null!;
+}

--- a/2 - Dominio/Sistema.CORE/Entities/MensagemLeitura.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/MensagemLeitura.cs
@@ -1,0 +1,12 @@
+namespace Sistema.CORE.Entities;
+
+public class MensagemLeitura
+{
+    public int Id { get; set; }
+    public int PublicacaoId { get; set; }
+    public Mensagem Publicacao { get; set; } = null!;
+    public int UsuarioId { get; set; }
+    public Usuario Usuario { get; set; } = null!;
+    public DateTime DataLeitura { get; set; } = DateTime.UtcNow;
+    public DateTime? DataEntrega { get; set; }
+}

--- a/2 - Dominio/Sistema.CORE/Entities/MensagemReacao.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/MensagemReacao.cs
@@ -1,0 +1,12 @@
+namespace Sistema.CORE.Entities;
+
+public class MensagemReacao
+{
+    public int Id { get; set; }
+    public int PublicacaoId { get; set; }
+    public Mensagem Publicacao { get; set; } = null!;
+    public int UsuarioId { get; set; }
+    public Usuario Usuario { get; set; } = null!;
+    public TipoReacao TipoReacao { get; set; }
+    public DateTime Data { get; set; } = DateTime.UtcNow;
+}

--- a/2 - Dominio/Sistema.CORE/Entities/PublicacaoEnums.cs
+++ b/2 - Dominio/Sistema.CORE/Entities/PublicacaoEnums.cs
@@ -1,0 +1,40 @@
+namespace Sistema.CORE.Entities;
+
+public enum PublicacaoTipo
+{
+    MensagemDireta = 1,
+    PostSetor = 2,
+    Aviso = 3
+}
+
+public enum PublicacaoStatus
+{
+    Ativa = 1,
+    Oculta = 2,
+    Excluida = 3,
+    Expirada = 4
+}
+
+public enum AvisoAudiencia
+{
+    Todos = 1,
+    Setor = 2,
+    Grupo = 3,
+    Usuarios = 4
+}
+
+public enum AvisoPrioridade
+{
+    Baixa = 1,
+    Normal = 2,
+    Alta = 3,
+    Critica = 4
+}
+
+public enum TipoReacao
+{
+    Curtir = 1,
+    Aplaudir = 2,
+    Apoiar = 3,
+    Interessante = 4
+}

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ILogRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/ILogRepository.cs
@@ -9,5 +9,7 @@ namespace Sistema.CORE.Repositories.Interfaces;
 public interface ILogRepository
 {
     Task AdicionarAsync(Log log, CancellationToken cancellationToken = default);
-    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default);
+    Task AdicionarEmLoteAsync(IEnumerable<Log> logs, CancellationToken cancellationToken = default);
+    Task<int> RemoverAntesDeAsync(LogModulo modulo, DateTime dataLimiteUtc, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, LogModulo? modulo = null, CancellationToken cancellationToken = default);
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IMensagemRepository.cs
@@ -10,6 +10,14 @@ namespace Sistema.CORE.Repositories.Interfaces
         Task<Mensagem?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
         IQueryable<Mensagem> Query();
         Task AddAsync(Mensagem mensagem, CancellationToken cancellationToken = default);
+        Task AddRangeAsync(IEnumerable<Mensagem> mensagens, CancellationToken cancellationToken = default);
         void Update(Mensagem mensagem);
+
+        IQueryable<MensagemReacao> QueryReacoes();
+        Task AddReacaoAsync(MensagemReacao reacao, CancellationToken cancellationToken = default);
+        void UpdateReacao(MensagemReacao reacao);
+
+        IQueryable<MensagemLeitura> QueryLeituras();
+        Task AddLeituraAsync(MensagemLeitura leitura, CancellationToken cancellationToken = default);
     }
 }

--- a/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
+++ b/2 - Dominio/Sistema.CORE/Repositories/Interfaces/IUsuarioRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ namespace Sistema.CORE.Repositories.Interfaces;
 
 public interface IUsuarioRepository
 {
+    IQueryable<Usuario> Query();
     Task<PagedResult<Usuario>> BuscarTodosAsync(int page, int pageSize, CancellationToken cancellationToken = default);
     Task<PagedResult<Usuario>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, int? perfilId, bool? ativo, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<Usuario?> BuscarPorIdAsync(int id, CancellationToken cancellationToken = default);

--- a/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/AppDbContext.cs
@@ -19,6 +19,9 @@ public class AppDbContext : DbContext
     public DbSet<Tema> Temas => Set<Tema>();
     public DbSet<Configuracao> Configuracoes => Set<Configuracao>();
     public DbSet<Mensagem> Mensagens => Set<Mensagem>();
+    public DbSet<MensagemReacao> MensagemReacoes => Set<MensagemReacao>();
+    public DbSet<MensagemLeitura> MensagemLeituras => Set<MensagemLeitura>();
+    public DbSet<MensagemDestinatario> MensagemDestinatarios => Set<MensagemDestinatario>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/3 - Infraestrutura/Sistema.INFRA/Data/DbInitializer.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/DbInitializer.cs
@@ -30,5 +30,11 @@ public static class DbInitializer
             context.Usuarios.AddRange(AdminUserSeed.Get(), ComercialUserSeed.Get());
             context.SaveChanges();
         }
+
+        if (!context.Configuracoes.Any())
+        {
+            context.Configuracoes.AddRange(ConfiguracaoSeed.Get());
+            context.SaveChanges();
+        }
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/ConfiguracaoSeed.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Data/Seeds/ConfiguracaoSeed.cs
@@ -4,46 +4,78 @@ namespace Sistema.INFRA.Data.Seeds;
 
 public static class ConfiguracaoSeed
 {
-	public static IEnumerable<Configuracao> Get()
-	{
-		return new List<Configuracao>
-		{
-			new()
-			{
-				Id = 1,
-				Agrupamento = "AzureAd",
-				Chave = "TenantId",
-				Valor = "",
-				Tipo = ConfiguracaoTipo.Texto,
-				UsuarioInclusao = "seed"
-			},
-			new()
-			{
-				Id = 2,
-				Agrupamento = "AzureAd",
-				Chave = "ClientId",
-				Valor = "",
-				Tipo = ConfiguracaoTipo.Texto,
-				UsuarioInclusao = "seed"
-			},
-			new()
-			{
-				Id = 3,
-				Agrupamento = "AzureAd",
-				Chave = "ClientSecret",
-				Valor = "",
-				Tipo = ConfiguracaoTipo.Password,
-				UsuarioInclusao = "seed"
-			},
-			new()
-			{
-				Id = 4,
-				Agrupamento = "AzureAd",
-				Chave = "SenderEmail",
-				Valor = "desenvolvimento@prumma.com.br",
-				Tipo = ConfiguracaoTipo.Email,
-				UsuarioInclusao = "seed"
-			}
-		};
-	}
+    public static IEnumerable<Configuracao> Get()
+    {
+        return new List<Configuracao>
+        {
+            new()
+            {
+                Agrupamento = "AzureAd",
+                Chave = "TenantId",
+                Valor = "",
+                Tipo = ConfiguracaoTipo.Texto,
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "AzureAd",
+                Chave = "ClientId",
+                Valor = "",
+                Tipo = ConfiguracaoTipo.Texto,
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "AzureAd",
+                Chave = "ClientSecret",
+                Valor = "",
+                Tipo = ConfiguracaoTipo.Password,
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "AzureAd",
+                Chave = "SenderEmail",
+                Valor = "desenvolvimento@prumma.com.br",
+                Tipo = ConfiguracaoTipo.Email,
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "LogsRetencao",
+                Chave = "AcessoMeses",
+                Valor = "3",
+                Tipo = ConfiguracaoTipo.Texto,
+                Descricao = "Tempo de retenção do log de acesso, em meses.",
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "LogsRetencao",
+                Chave = "ComunicacaoMeses",
+                Valor = "6",
+                Tipo = ConfiguracaoTipo.Texto,
+                Descricao = "Tempo de retenção do log de comunicação, em meses.",
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "LogsRetencao",
+                Chave = "AdministracaoMeses",
+                Valor = "12",
+                Tipo = ConfiguracaoTipo.Texto,
+                Descricao = "Tempo de retenção do log de administração, em meses.",
+                UsuarioInclusao = "seed"
+            },
+            new()
+            {
+                Agrupamento = "LogsRetencao",
+                Chave = "GeralMeses",
+                Valor = "12",
+                Tipo = ConfiguracaoTipo.Texto,
+                Descricao = "Tempo de retenção do log geral, em meses.",
+                UsuarioInclusao = "seed"
+            }
+        };
+    }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/LogMap.cs
@@ -14,5 +14,11 @@ public class LogMap : IEntityTypeConfiguration<Log>
         builder.Property(l => l.Operacao).IsRequired().HasMaxLength(100);
         builder.Property(l => l.Mensagem).IsRequired().HasMaxLength(2000);
         builder.Property(l => l.Usuario).IsRequired().HasMaxLength(100);
+        builder.Property(l => l.CorrelationId).HasMaxLength(100);
+        builder.Property(l => l.TraceId).HasMaxLength(64);
+        builder.Property(l => l.SpanId).HasMaxLength(32);
+        builder.Property(l => l.Modulo).IsRequired();
+        builder.HasIndex(l => new { l.Modulo, l.DataOperacao });
+        builder.HasIndex(l => l.CorrelationId);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemDestinatarioMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemDestinatarioMap.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class MensagemDestinatarioMap : IEntityTypeConfiguration<MensagemDestinatario>
+{
+    public void Configure(EntityTypeBuilder<MensagemDestinatario> builder)
+    {
+        builder.ToTable("MensagemDestinatarios");
+        builder.HasKey(x => new { x.MensagemId, x.UsuarioId });
+
+        builder.HasOne(x => x.Usuario)
+            .WithMany()
+            .HasForeignKey(x => x.UsuarioId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemLeituraMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemLeituraMap.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class MensagemLeituraMap : IEntityTypeConfiguration<MensagemLeitura>
+{
+    public void Configure(EntityTypeBuilder<MensagemLeitura> builder)
+    {
+        builder.ToTable("MensagemLeituras");
+        builder.HasKey(x => x.Id);
+
+        builder.HasIndex(x => new { x.PublicacaoId, x.UsuarioId }).IsUnique();
+
+        builder.HasOne(x => x.Usuario)
+            .WithMany()
+            .HasForeignKey(x => x.UsuarioId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemMap.cs
@@ -12,6 +12,12 @@ namespace Sistema.INFRA.Mapping
 
             builder.HasKey(m => m.Id);
 
+            builder.HasOne(m => m.Autor)
+                .WithMany()
+                .HasForeignKey(m => m.AutorId)
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Restrict);
+
             builder.HasOne(m => m.Remetente)
                 .WithMany()
                 .HasForeignKey(m => m.RemetenteId)
@@ -21,15 +27,36 @@ namespace Sistema.INFRA.Mapping
             builder.HasOne(m => m.Destinatario)
                 .WithMany()
                 .HasForeignKey(m => m.DestinatarioId)
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(m => m.Perfil)
+                .WithMany()
+                .HasForeignKey(m => m.PerfilId)
+                .IsRequired(false)
                 .OnDelete(DeleteBehavior.Restrict);
 
             builder.HasOne(m => m.MensagemPai)
                 .WithMany(m => m.Respostas)
                 .HasForeignKey(m => m.MensagemPaiId)
-                .IsRequired(false);
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Restrict);
 
             builder.Property(m => m.Assunto).HasMaxLength(200);
             builder.Property(m => m.Corpo).IsRequired().HasMaxLength(5000);
+            builder.Property(m => m.AvisoGrupo).HasMaxLength(100);
+
+            builder.HasMany(m => m.DestinatariosExplicitos)
+                .WithOne(d => d.Mensagem)
+                .HasForeignKey(d => d.MensagemId);
+
+            builder.HasMany(m => m.Reacoes)
+                .WithOne(r => r.Publicacao)
+                .HasForeignKey(r => r.PublicacaoId);
+
+            builder.HasMany(m => m.Leituras)
+                .WithOne(l => l.Publicacao)
+                .HasForeignKey(l => l.PublicacaoId);
         }
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemReacaoMap.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Mapping/MensagemReacaoMap.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Sistema.CORE.Entities;
+
+namespace Sistema.INFRA.Mapping;
+
+public class MensagemReacaoMap : IEntityTypeConfiguration<MensagemReacao>
+{
+    public void Configure(EntityTypeBuilder<MensagemReacao> builder)
+    {
+        builder.ToTable("MensagemReacoes");
+        builder.HasKey(x => x.Id);
+
+        builder.HasIndex(x => new { x.PublicacaoId, x.UsuarioId }).IsUnique();
+
+        builder.HasOne(x => x.Usuario)
+            .WithMany()
+            .HasForeignKey(x => x.UsuarioId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/LogRepository.cs
@@ -9,12 +9,24 @@ public class LogRepository(AppDbContext context) : ILogRepository
 {
     private readonly AppDbContext _context = context;
 
-	public async Task AdicionarAsync(Log log, CancellationToken cancellationToken = default)
+    public async Task AdicionarAsync(Log log, CancellationToken cancellationToken = default)
     {
         await _context.Logs.AddAsync(log, cancellationToken);
     }
 
-    public async Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, CancellationToken cancellationToken = default)
+    public async Task AdicionarEmLoteAsync(IEnumerable<Log> logs, CancellationToken cancellationToken = default)
+    {
+        await _context.Logs.AddRangeAsync(logs, cancellationToken);
+    }
+
+    public async Task<int> RemoverAntesDeAsync(LogModulo modulo, DateTime dataLimiteUtc, CancellationToken cancellationToken = default)
+    {
+        return await _context.Logs
+            .Where(l => l.Modulo == modulo && l.DataOperacao < dataLimiteUtc)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<Log>> BuscarFiltradosAsync(DateTime? inicio, DateTime? fim, LogTipo? tipo, LogModulo? modulo = null, CancellationToken cancellationToken = default)
     {
         var query = _context.Logs.AsQueryable();
         if (inicio.HasValue)
@@ -23,6 +35,9 @@ public class LogRepository(AppDbContext context) : ILogRepository
             query = query.Where(l => l.DataOperacao <= fim.Value);
         if (tipo.HasValue)
             query = query.Where(l => l.Tipo == tipo.Value);
-        return await query.AsNoTracking().ToListAsync(cancellationToken);
+        if (modulo.HasValue)
+            query = query.Where(l => l.Modulo == modulo.Value);
+
+        return await query.AsNoTracking().OrderByDescending(l => l.DataOperacao).ToListAsync(cancellationToken);
     }
 }

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/MensagemRepository.cs
@@ -9,16 +9,24 @@ namespace Sistema.INFRA.Repositories
     {
         private readonly AppDbContext _context = context;
 
-		public async Task AddAsync(Mensagem mensagem, CancellationToken cancellationToken = default)
+        public async Task AddAsync(Mensagem mensagem, CancellationToken cancellationToken = default)
         {
             await _context.Mensagens.AddAsync(mensagem, cancellationToken);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Mensagem> mensagens, CancellationToken cancellationToken = default)
+        {
+            await _context.Mensagens.AddRangeAsync(mensagens, cancellationToken);
         }
 
         public async Task<Mensagem?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             return await _context.Mensagens
+                .Include(m => m.Autor)
                 .Include(m => m.Remetente)
                 .Include(m => m.Destinatario)
+                .Include(m => m.Perfil)
+                .Include(m => m.Reacoes)
                 .Include(m => m.MensagemPai)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
@@ -27,9 +35,31 @@ namespace Sistema.INFRA.Repositories
         public IQueryable<Mensagem> Query()
         {
             return _context.Mensagens
+                .Include(m => m.Autor)
                 .Include(m => m.Remetente)
                 .Include(m => m.Destinatario)
+                .Include(m => m.Perfil)
+                .Include(m => m.Reacoes)
                 .AsNoTracking();
+        }
+
+        public IQueryable<MensagemReacao> QueryReacoes() => _context.MensagemReacoes.AsQueryable();
+
+        public async Task AddReacaoAsync(MensagemReacao reacao, CancellationToken cancellationToken = default)
+        {
+            await _context.MensagemReacoes.AddAsync(reacao, cancellationToken);
+        }
+
+        public void UpdateReacao(MensagemReacao reacao)
+        {
+            _context.MensagemReacoes.Update(reacao);
+        }
+
+        public IQueryable<MensagemLeitura> QueryLeituras() => _context.MensagemLeituras.AsQueryable();
+
+        public async Task AddLeituraAsync(MensagemLeitura leitura, CancellationToken cancellationToken = default)
+        {
+            await _context.MensagemLeituras.AddAsync(leitura, cancellationToken);
         }
 
         public void Update(Mensagem mensagem)

--- a/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
+++ b/3 - Infraestrutura/Sistema.INFRA/Repositories/UsuarioRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
@@ -9,6 +10,11 @@ namespace Sistema.INFRA.Repositories;
 public class UsuarioRepository(AppDbContext context) : IUsuarioRepository
 {
     private readonly AppDbContext _context = context;
+
+    public IQueryable<Usuario> Query()
+    {
+        return _context.Usuarios.AsQueryable();
+    }
 
 	public async Task<Usuario> AdicionarAsync(Usuario usuario, CancellationToken cancellationToken = default)
     {

--- a/4 - Testes/Sistema.Tests/AccountControllerTests.cs
+++ b/4 - Testes/Sistema.Tests/AccountControllerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Sistema.APP.Services.Interfaces;
 using Sistema.CORE.Common;
 using Sistema.CORE.Entities;
+using Sistema.CORE.Repositories.Interfaces;
 using Sistema.MVC.Controllers;
 using Sistema.MVC.Models;
 
@@ -19,6 +20,8 @@ public class AccountControllerTests
         var hasher = new Mock<IPasswordHasher<Usuario>>();
         var emailService = new Mock<IEmailAppService>();
         var logger = new Mock<ILogger<AccountController>>();
+        var logService = new Mock<ILogAppService>();
+        var uow = new Mock<IUnitOfWork>();
 
         hasher
             .Setup(h => h.HashPassword(It.IsAny<Usuario>(), It.IsAny<string>()))
@@ -28,7 +31,7 @@ public class AccountControllerTests
             .Setup(s => s.AdicionarAsync(It.IsAny<Usuario>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OperationResult<Usuario>(true, "ok"));
 
-        var controller = new AccountController(usuarioService.Object, hasher.Object, emailService.Object, logger.Object);
+        var controller = new AccountController(usuarioService.Object, hasher.Object, emailService.Object, logger.Object, logService.Object, uow.Object);
         var model = new RegisterViewModel
         {
             Nome = "Usuário Teste",
@@ -52,6 +55,8 @@ public class AccountControllerTests
         var hasher = new Mock<IPasswordHasher<Usuario>>();
         var emailService = new Mock<IEmailAppService>();
         var logger = new Mock<ILogger<AccountController>>();
+        var logService = new Mock<ILogAppService>();
+        var uow = new Mock<IUnitOfWork>();
 
         hasher
             .Setup(h => h.HashPassword(It.IsAny<Usuario>(), It.IsAny<string>()))
@@ -61,7 +66,7 @@ public class AccountControllerTests
             .Setup(s => s.AdicionarAsync(It.IsAny<Usuario>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("falha simulada"));
 
-        var controller = new AccountController(usuarioService.Object, hasher.Object, emailService.Object, logger.Object);
+        var controller = new AccountController(usuarioService.Object, hasher.Object, emailService.Object, logger.Object, logService.Object, uow.Object);
         var model = new RegisterViewModel
         {
             Nome = "Usuário Teste",

--- a/4 - Testes/Sistema.Tests/AuthAppServiceTests.cs
+++ b/4 - Testes/Sistema.Tests/AuthAppServiceTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Sistema.APP.Services;
 using Sistema.CORE.Entities;
 using Sistema.CORE.Repositories.Interfaces;
+using Sistema.APP.Services.Interfaces;
 
 namespace Sistema.Tests;
 
@@ -15,6 +16,7 @@ public class AuthAppServiceTests
         var usuarioRepository = new Mock<IUsuarioRepository>();
         var unitOfWork = new Mock<IUnitOfWork>();
         var hasher = new Mock<IPasswordHasher<Usuario>>();
+        var logService = new Mock<ILogAppService>();
 
         var usuario = new Usuario
         {
@@ -44,7 +46,7 @@ public class AuthAppServiceTests
             })
             .Build();
 
-        var service = new AuthAppService(unitOfWork.Object, hasher.Object, config);
+        var service = new AuthAppService(unitOfWork.Object, hasher.Object, config, logService.Object);
 
         var token = await service.AutenticarAsync(usuario.Cpf, "Senha@123");
 
@@ -57,6 +59,7 @@ public class AuthAppServiceTests
         var usuarioRepository = new Mock<IUsuarioRepository>();
         var unitOfWork = new Mock<IUnitOfWork>();
         var hasher = new Mock<IPasswordHasher<Usuario>>();
+        var logService = new Mock<ILogAppService>();
 
         var usuario = new Usuario
         {
@@ -86,7 +89,7 @@ public class AuthAppServiceTests
             })
             .Build();
 
-        var service = new AuthAppService(unitOfWork.Object, hasher.Object, config);
+        var service = new AuthAppService(unitOfWork.Object, hasher.Object, config, logService.Object);
 
         var token = await service.AutenticarAsync(usuario.Cpf, "senha-invalida");
 

--- a/README.md
+++ b/README.md
@@ -6,38 +6,72 @@ Projeto de exemplo em .NET 8 utilizando arquitetura em camadas.
 - **0 - Apresentacao**:
   - `Sistema.API` - API ASP.NET Core com Swagger e Serilog.
   - `Sistema.MVC` - frontend web MVC para autenticação, cadastro, recuperação de senha, documentação e edição de tema.
-- **1 - Aplicacao**: `Sistema.APP` - perfis do AutoMapper e registro de dependências.
-- **2 - Dominio**: `Sistema.CORE` - entidades e implementações dos serviços que definem as regras de negócio.
+- **1 - Aplicacao**: `Sistema.APP` - perfis do AutoMapper, serviços de aplicação e registro de dependências.
+- **2 - Dominio**: `Sistema.CORE` - entidades e regras de negócio.
 - **3 - Infraestrutura**: `Sistema.INFRA` - Entity Framework Core, repositórios, Unit of Work, serviços e seeds.
+- **4 - Testes**: `Sistema.Tests` - testes unitários.
 
-### Organização de pastas
-- `2 - Dominio/Sistema.CORE/Entities` contém todas as entidades do domínio.
-- `2 - Dominio/Sistema.CORE/Services` possui as implementações dos serviços e suas interfaces em `Services/Interfaces`.
-- `3 - Infraestrutura/Sistema.INFRA/Repositories` contém as implementações dos repositórios.
-- `2 - Dominio/Sistema.CORE/Repositories/Interfaces` guarda apenas as interfaces dos repositórios.
-- `1 - Aplicacao/Sistema.APP/DTOs` concentra os DTOs utilizados pela API.
-- `0 - Apresentacao/Sistema.MVC` reúne controllers, views e arquivos estáticos do frontend.
-- `3 - Infraestrutura/Sistema.INFRA/Services` disponibiliza serviços como envio de e-mails.
+## Funcionalidades principais
+- Hub de comunicação interna com três tipos de publicação:
+  - mensagem direta
+  - post de setor
+  - aviso institucional
+- Threads sociais com respostas em cadeia (pai/filho).
+- Reações por usuário/publicação com unicidade por item.
+- Controle de leitura/entrega em publicações.
+- Auditoria de operações por módulo (`Acesso`, `Comunicacao`, `Administracao`) em tabela única de logs.
 
-## Funcionalidades
-- CRUD de `Perfil`, `Usuario`, `Funcionalidade` e `Tema` com validações de negócio.
-- Campos de auditoria nas entidades e registro de operações em `Log`.
-- `UnitOfWork` centraliza o commit das alterações.
-- Seeds criam perfis, funcionalidades e usuários iniciais (Admin e Comercial).
-- Serilog grava logs mensais na pasta `log` e as operações também ficam salvas na tabela `Logs` com usuário e detalhes da exceção.
-- Perfis e usuários podem ser ativados ou desativados e as APIs permitem filtrar registros por data, perfil e status.
-- Listagens retornam `PagedResult<T>` para suportar paginação via `page` e `pageSize`.
-- Perfis possuem funcionalidades com permissões de leitura e escrita gravadas em `PerfilFuncionalidades`.
-- Autenticação via JWT protege a API; obtenha um token em `/api/auth/login`.
-- Interface MVC permite login, registro, recuperação de senha, consulta à documentação e personalização de tema.
-- `EmailService` envia mensagens SMTP para cadastro e recuperação de senha.
+## Auditoria e retenção de logs
+A aplicação utiliza tabela única de `Log` com campo `Modulo` para segmentação lógica.
 
-Para compilar a solução:
+### Endpoints de consulta
+- `GET /api/log`
+- `GET /api/log/acesso`
+- `GET /api/log/comunicacao`
+- `GET /api/log/administracao`
+
+### Correlação de requisições
+- A aplicação propaga `X-Correlation-ID` em API e MVC.
+- O valor é gravado no log em `CorrelationId` e pode ser usado para rastrear ponta a ponta.
+
+### Retenção por módulo (configurável via sistema)
+As regras de retenção são lidas do agrupamento de configuração **`LogsRetencao`**:
+- `AcessoMeses` (padrão: 3)
+- `ComunicacaoMeses` (padrão: 6)
+- `AdministracaoMeses` (padrão: 12)
+- `GeralMeses` (padrão: 12)
+
+Você pode editar esses valores na tela de configurações (`/Configuracao`) filtrando pelo agrupamento `LogsRetencao`.
+
+## Consistência transacional de logs
+- O `LogAppService` não confirma transação por conta própria.
+- O commit permanece no serviço/caso de uso chamador para manter consistência entre operação de negócio e auditoria.
+
+## Fallback de log (resiliência)
+Se ocorrer falha ao gravar log no banco, o sistema grava o evento em arquivo interno:
+- `log-fallback/audit-fallback.ndjson`
+
+Quando a gravação no banco volta a funcionar, os registros do arquivo fallback são migrados automaticamente para a tabela de logs e removidos do arquivo.
+
+## Seeds
+Na inicialização, o sistema cria dados iniciais de:
+- perfis
+- funcionalidades
+- usuários
+- configurações (incluindo `LogsRetencao`)
+
+## Build e testes
+Para compilar:
 
 ```bash
-dotnet build Sistema.sln -c Release
+dotnet build Sistema.sln -warnaserror
 ```
 
+Para executar testes:
+
+```bash
+dotnet test Sistema.sln --no-build
+```
 
 ## Estilos com Sass
 Os estilos do projeto foram organizados com [Sass](https://sass-lang.com/).
@@ -51,6 +85,5 @@ npm run build-css
 ```
 
 ## Scripts com jQuery
-
-- `0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js` agora utiliza jQuery para controlar menus, tema e outras interações.
-- A tag `<html>` do layout foi configurada com `lang="pt-BR"` para indicar o idioma da aplicação.
+- `0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js` utiliza jQuery para controlar menus, tema e outras interações.
+- A tag `<html>` do layout está configurada com `lang="pt-BR"`.


### PR DESCRIPTION
### Motivation
- Introduce a richer internal communication model (feed with posts, sector posts and notices) and support social features like reactions and read-tracking. 
- Improve auditing to support module segmentation, request correlation and resilient persistence when the database is unavailable. 
- Expose UI and API endpoints to consume the new communication features and to query module-scoped logs. 

### Description
- Domain and persistence: new entities and enums for publications, reactions and reads (`MensagemReacao`, `MensagemLeitura`, `MensagemDestinatario`, `PublicacaoTipo`, `PublicacaoStatus`, `AvisoAudiencia`, `AvisoPrioridade`, `TipoReacao`) and additions to `Mensagem` and `Log` (module, correlation/trace/span ids); DB mappings and `AppDbContext` updated. 
- Application services and repositories: extended `IMensagemAppService` and `ILogAppService` with feed, publication creation, reactions, module-scoped log queries and admin retention APIs; implemented `MensagemAppService` and `LogAppService` logic for feed filtering, permission checks, reaction/read handling, fallback NDJSON file writing (`log-fallback/audit-fallback.ndjson`) and migration, and automatic retention based on configurable `LogsRetencao` keys. 
- API and MVC: added `Feed`, reaction and publication endpoints in `MensagemController` (API) and MVC controllers/views updated for a unified composer (direct message / post / aviso), feed UI, reactions and filters; added `LogController` module endpoints (`/api/log/acesso`, `/api/log/comunicacao`, `/api/log/administracao`). 
- Infrastructure and infra seeds: repository interfaces and implementations extended for batch log add, deletes by date, queries for reactions/reads, new EF mappings and seeds for `LogsRetencao` defaults; middleware added to propagate `X-Correlation-ID` in both API and MVC `Program.cs`. 
- Misc: AutoMapper mappings and DTOs extended (`MensagemDto`, `MensagemThreadDto`, `NovaMensagemDto`, `FeedFiltroDto`, `ReagirPublicacaoDto`), `HttpContextAccessor` registration added and README updated with new endpoints and retention info. 

### Testing
- Unit tests updated to accommodate new service dependencies and run: `AccountControllerTests` succeeded. 
- Authentication tests updated and run: `AuthAppServiceTests` succeeded. 
- No failing automated tests were reported after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36cd81364832c81b6a2480ea9aced)