### PR TITLE
Refactor sidebar/menu layout, remove iconbar, add Playwright layout checks and log migration fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /0 - Apresentacao/Sistema.API/log
 node_modules/
 /.vs/Sistema/CopilotIndices/17.14.1347.20289
+artifacts/screenshots/*.png

--- a/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
+++ b/0 - Apresentacao/Sistema.MVC/Views/Shared/_Layout.cshtml
@@ -28,10 +28,6 @@
     bool footerFixo = tema?.FooterFixo ?? false;
     bool menuExpandido = tema?.MenuLateralExpandido ?? true;
     var unreadMessages = userId > 0 ? await MensagemService.ContarNaoLidasAsync(userId) : 0;
-    var userInitial = !string.IsNullOrWhiteSpace(userName)
-        ? char.ToUpper(userName.Trim()[0], CultureInfo.CurrentCulture).ToString()
-        : "U";
-
     string EstaAtivo(string controller, string? action = null)
     {
         var currentController = ViewContext.RouteData.Values["controller"]?.ToString();
@@ -103,46 +99,13 @@
             </div>
         </header>
         <div class="flex-grow-1 d-flex app-shell">
-            <div class="app-iconbar sidebar-bg @leftText" aria-label="Atalhos rápidos">
-                <a class="icon-link" asp-controller="Home" asp-action="Index" title="Início">
-                    <i class="bi bi-house"></i>
-                </a>
-                <a class="icon-link" asp-controller="Mensagem" asp-action="Index" title="Mensagens">
-                    <i class="bi bi-envelope"></i>
-                </a>
-                <a class="icon-link" asp-controller="Configuracao" asp-action="Index" title="Configurações">
-                    <i class="bi bi-gear"></i>
-                </a>
-                <a class="icon-link" asp-controller="Tema" asp-action="Edit" title="Tema">
-                    <i class="bi bi-palette"></i>
-                </a>
-                <a class="icon-link" asp-controller="Account" asp-action="Logout" title="Sair">
-                    <i class="bi bi-box-arrow-right"></i>
-                </a>
-            </div>
             <nav id="sidebarMenu" class="app-menu sidebar-bg @leftText" aria-label="Menu principal"
                  data-menu-expanded="@menuExpandido.ToString().ToLowerInvariant()">
                 <ul class="nav flex-column">
-                    <li class="menu-brand">
-                        <div class="menu-brand-icon rounded-circle d-inline-flex align-items-center justify-content-center me-2">
-                            <i class="bi bi-grid-1x2-fill"></i>
-                        </div>
-                        <div class="menu-brand-text">
-                            <small class="text-opacity-75 d-block">Painel</small>
-                            <span class="fw-semibold">Sistema.MVC</span>
-                        </div>
-                    </li>
-                    <li class="menu-user d-flex align-items-center">
-                        <div class="menu-avatar me-3">@userInitial</div>
-                        <div class="menu-user-text">
-                            <div class="fw-semibold text-truncate">@userName</div>
-                            <small class="text-opacity-75">Bem-vindo(a)</small>
-                        </div>
-                    </li>
                     <li class="nav-header text-uppercase small">Módulos</li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Home")" asp-controller="Home" asp-action="Index" title="Módulo Home">
-                            <i class="bi bi-house me-2"></i><span>Módulo Home</span>
+                        <a class="nav-link @leftText @EstaAtivo("Home")" href="#" title="Home">
+                            <i class="bi bi-house me-2"></i><span>Home</span>
                         </a>
                         <ul>
                             <li><a asp-controller="Home" asp-action="Index" title="Dashboard">Dashboard</a></li>
@@ -150,8 +113,8 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Account")" asp-controller="Account" asp-action="Login" title="Módulo Acesso">
-                            <i class="bi bi-shield-lock me-2"></i><span>Módulo Acesso</span>
+                        <a class="nav-link @leftText @EstaAtivo("Account")" href="#" title="Acesso">
+                            <i class="bi bi-shield-lock me-2"></i><span>Acesso</span>
                         </a>
                         <ul>
                             <li><a asp-controller="Account" asp-action="ChangePassword" title="Segurança">Segurança</a></li>
@@ -159,8 +122,8 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Mensagem")" asp-controller="Mensagem" asp-action="Index" title="Módulo Comunicação">
-                            <i class="bi bi-envelope me-2"></i><span>Módulo Comunicação</span>
+                        <a class="nav-link @leftText @EstaAtivo("Mensagem")" href="#" title="Comunicação">
+                            <i class="bi bi-envelope me-2"></i><span>Comunicação</span>
                             @if (unreadMessages > 0)
                             {
                                 <span class="badge bg-primary ms-auto">@unreadMessages</span>
@@ -174,8 +137,8 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Configuracao")" asp-controller="Configuracao" asp-action="Index" title="Módulo Administração">
-                            <i class="bi bi-gear me-2"></i><span>Módulo Administração</span>
+                        <a class="nav-link @leftText @EstaAtivo("Configuracao")" href="#" title="Administração">
+                            <i class="bi bi-gear me-2"></i><span>Administração</span>
                         </a>
                         <ul>
                             <li><a asp-controller="Configuracao" asp-action="Index" title="Configurações">Configurações</a></li>
@@ -184,8 +147,8 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @leftText @EstaAtivo("Documentacao")" asp-controller="Documentacao" asp-action="Index" title="Módulo Documentação">
-                            <i class="bi bi-book me-2"></i><span>Módulo Documentação</span>
+                        <a class="nav-link @leftText @EstaAtivo("Documentacao")" href="#" title="Documentação">
+                            <i class="bi bi-book me-2"></i><span>Documentação</span>
                         </a>
                         <ul>
                             <li><a asp-controller="Documentacao" asp-action="Index" asp-fragment="mensagens" title="Mensagens">Mensagens</a></li>

--- a/0 - Apresentacao/Sistema.MVC/appsettings.Development.json
+++ b/0 - Apresentacao/Sistema.MVC/appsettings.Development.json
@@ -5,6 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "UseInMemoryDatabase": true,
   "Api": {
     "BaseAddress": "http://localhost:5057"
   } 

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_menu.scss
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/sass/_menu.scss
@@ -2,7 +2,7 @@
 
 .app-shell {
   gap: 0;
-  min-height: 0;
+  min-height: calc(100vh - var(--layout-offset-top, 0px) - var(--layout-offset-bottom, 0px));
   width: 100%;
   align-items: stretch;
 }
@@ -11,21 +11,30 @@
   min-width: 0;
   overflow-x: auto;
   flex: 1 1 0;
+  margin-left: var(--mm-sidebar-panel-size);
+  transition: margin-left 0.25s ease;
+}
+
+.app-shell .content > main {
+  overflow-x: hidden;
 }
 
 .app-menu {
   color: inherit;
-  flex: 0 0 var(--mm-sidebar-panel-size);
-  max-width: var(--mm-sidebar-panel-size);
   width: var(--mm-sidebar-panel-size);
-  min-height: 100%;
-  position: relative;
+  max-width: var(--mm-sidebar-panel-size);
+  min-height: 100dvh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 1025;
   overflow: hidden;
   transition: transform 0.25s ease, opacity 0.25s ease;
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.08);
 
   .nav {
-    padding: 0.5rem 0.25rem 1rem;
+    padding: 0.75rem 0.25rem 1rem;
     gap: 0.15rem;
     margin: 0;
     height: 100%;
@@ -39,7 +48,7 @@
     inset: 0;
     list-style: none;
     margin: 0;
-    padding: 0.5rem 0.25rem 1rem;
+    padding: 0.75rem 0.25rem 1rem;
     transform: translateX(100%);
     transition: transform 0.25s ease;
     overflow-y: auto;
@@ -122,50 +131,6 @@
     padding: 0.75rem 1rem 0.25rem;
   }
 
-  .nav-item + .nav-header {
-    margin-top: 0.35rem;
-  }
-
-  .menu-brand,
-  .menu-user {
-    padding: 1rem 1.25rem 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  }
-
-  .menu-brand {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-  }
-
-  .menu-brand-icon {
-    width: 40px;
-    height: 40px;
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    color: inherit;
-  }
-
-  .menu-brand-text small {
-    letter-spacing: 0.08em;
-  }
-
-  .menu-user {
-    gap: 0.75rem;
-  }
-
-  .menu-avatar {
-    width: 44px;
-    height: 44px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.14);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    font-weight: 700;
-  }
-
   .nav-link {
     display: flex;
     align-items: center;
@@ -208,42 +173,6 @@
   }
 }
 
-.app-iconbar {
-  flex: 0 0 var(--iconbar-width);
-  max-width: var(--iconbar-width);
-  width: var(--iconbar-width);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 0.25rem;
-  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.08);
-
-  .icon-link {
-    width: 44px;
-    height: 44px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 12px;
-    color: inherit;
-    text-decoration: none;
-    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-
-    &:hover,
-    &:focus-visible {
-      background-color: rgba(255, 255, 255, 0.12);
-      color: #fff;
-      transform: translateY(-1px);
-    }
-
-    &:focus-visible {
-      outline: 2px solid currentColor;
-      outline-offset: 2px;
-    }
-  }
-}
-
 .mobile-menu-toggle {
   display: none;
 }
@@ -258,10 +187,6 @@
   }
 
   .app-menu {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
     z-index: 1100;
     width: min(320px, 86vw);
     max-width: min(320px, 86vw);
@@ -272,6 +197,10 @@
 
   body.menu-mobile-open .app-menu {
     transform: translateX(0);
+  }
+
+  .app-shell .content {
+    margin-left: 0;
   }
 
   .sidebar-menu-backdrop {
@@ -288,34 +217,17 @@
     opacity: 1;
     pointer-events: auto;
   }
-
-  .app-iconbar {
-    display: none;
-  }
 }
 
 @media (min-width: 992px) {
+  body.menu-desktop-collapsed .app-shell .content {
+    margin-left: 0;
+  }
+
   body.menu-desktop-collapsed .app-menu {
-    position: absolute;
-    top: 0;
-    left: var(--iconbar-width);
-    bottom: 0;
-    min-height: 100%;
-    transform: translateX(calc(-100% + 22px));
+    transform: translateX(-100%);
     opacity: 0;
     pointer-events: none;
     z-index: 1080;
-  }
-
-  body.menu-desktop-collapsed.menu-hover-open .app-menu,
-  body.menu-desktop-collapsed .app-menu:hover {
-    transform: translateX(0);
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  body.menu-desktop-collapsed .app-iconbar {
-    position: relative;
-    z-index: 1085;
   }
 }

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/css/site.css
@@ -104,7 +104,7 @@ footer.footer {
 
 .app-shell {
   gap: 0;
-  min-height: 0;
+  min-height: calc(100vh - var(--layout-offset-top, 0px) - var(--layout-offset-bottom, 0px));
   width: 100%;
   align-items: stretch;
 }
@@ -113,21 +113,29 @@ footer.footer {
   min-width: 0;
   overflow-x: auto;
   flex: 1 1 0;
+  margin-left: var(--mm-sidebar-panel-size);
+  transition: margin-left 0.25s ease;
+}
+.app-shell .content > main {
+  overflow-x: hidden;
 }
 
 .app-menu {
   color: inherit;
-  flex: 0 0 var(--mm-sidebar-panel-size);
-  max-width: var(--mm-sidebar-panel-size);
   width: var(--mm-sidebar-panel-size);
-  min-height: 100%;
-  position: relative;
+  max-width: var(--mm-sidebar-panel-size);
+  min-height: 100dvh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 1025;
   overflow: hidden;
   transition: transform 0.25s ease, opacity 0.25s ease;
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.08);
 }
 .app-menu .nav {
-  padding: 0.5rem 0.25rem 1rem;
+  padding: 0.75rem 0.25rem 1rem;
   gap: 0.15rem;
   margin: 0;
   height: 100%;
@@ -140,7 +148,7 @@ footer.footer {
   inset: 0;
   list-style: none;
   margin: 0;
-  padding: 0.5rem 0.25rem 1rem;
+  padding: 0.75rem 0.25rem 1rem;
   transform: translateX(100%);
   transition: transform 0.25s ease;
   overflow-y: auto;
@@ -209,43 +217,6 @@ footer.footer {
   opacity: 0.7;
   padding: 0.75rem 1rem 0.25rem;
 }
-.app-menu .nav-item + .nav-header {
-  margin-top: 0.35rem;
-}
-.app-menu .menu-brand,
-.app-menu .menu-user {
-  padding: 1rem 1.25rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-.app-menu .menu-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-}
-.app-menu .menu-brand-icon {
-  width: 40px;
-  height: 40px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  color: inherit;
-}
-.app-menu .menu-brand-text small {
-  letter-spacing: 0.08em;
-}
-.app-menu .menu-user {
-  gap: 0.75rem;
-}
-.app-menu .menu-avatar {
-  width: 44px;
-  height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  font-weight: 700;
-}
 .app-menu .nav-link {
   display: flex;
   align-items: center;
@@ -282,38 +253,6 @@ footer.footer {
   color: var(--bs-primary);
 }
 
-.app-iconbar {
-  flex: 0 0 var(--iconbar-width);
-  max-width: var(--iconbar-width);
-  width: var(--iconbar-width);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 0.25rem;
-  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.08);
-}
-.app-iconbar .icon-link {
-  width: 44px;
-  height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  color: inherit;
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-.app-iconbar .icon-link:hover, .app-iconbar .icon-link:focus-visible {
-  background-color: rgba(255, 255, 255, 0.12);
-  color: #fff;
-  transform: translateY(-1px);
-}
-.app-iconbar .icon-link:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
-}
-
 .mobile-menu-toggle {
   display: none;
 }
@@ -327,10 +266,6 @@ footer.footer {
     padding: 0.25rem 0.5rem;
   }
   .app-menu {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
     z-index: 1100;
     width: min(320px, 86vw);
     max-width: min(320px, 86vw);
@@ -340,6 +275,9 @@ footer.footer {
   }
   body.menu-mobile-open .app-menu {
     transform: translateX(0);
+  }
+  .app-shell .content {
+    margin-left: 0;
   }
   .sidebar-menu-backdrop {
     position: fixed;
@@ -354,31 +292,16 @@ footer.footer {
     opacity: 1;
     pointer-events: auto;
   }
-  .app-iconbar {
-    display: none;
-  }
 }
 @media (min-width: 992px) {
+  body.menu-desktop-collapsed .app-shell .content {
+    margin-left: 0;
+  }
   body.menu-desktop-collapsed .app-menu {
-    position: absolute;
-    top: 0;
-    left: var(--iconbar-width);
-    bottom: 0;
-    min-height: 100%;
-    transform: translateX(calc(-100% + 22px));
+    transform: translateX(-100%);
     opacity: 0;
     pointer-events: none;
     z-index: 1080;
-  }
-  body.menu-desktop-collapsed.menu-hover-open .app-menu,
-  body.menu-desktop-collapsed .app-menu:hover {
-    transform: translateX(0);
-    opacity: 1;
-    pointer-events: auto;
-  }
-  body.menu-desktop-collapsed .app-iconbar {
-    position: relative;
-    z-index: 1085;
   }
 }
 :root {

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/menu.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/menu.js
@@ -11,7 +11,6 @@
         const config = {
             sidebarSelector: '#sidebarMenu',
             mobileToggleSelector: '.mobile-menu-toggle',
-            iconbarSelector: '.app-iconbar',
             appShellSelector: '.app-shell',
             expandedCheckboxSelector: '#MenuLateralExpandido',
             onMobileStateChange: null,
@@ -22,7 +21,6 @@
         if (!$sidebar.length) return null;
 
         const $mobileToggle = $(config.mobileToggleSelector);
-        const $iconbar = $(config.iconbarSelector);
         const $appShell = $(config.appShellSelector);
         const $expandedCheckbox = $(config.expandedCheckboxSelector);
         const desktopMedia = window.matchMedia('(min-width: 992px)');
@@ -134,6 +132,15 @@
                 $(this).attr('aria-expanded', 'true');
             });
 
+            $sidebar.on('click', '.nav-item > .nav-link', function (e) {
+                const $item = $(this).closest('.nav-item');
+                const $submenu = $item.children('.menu-subpanel').first();
+                if (!$submenu.length) return;
+
+                e.preventDefault();
+                $item.children('.submenu-toggle').trigger('click');
+            });
+
             $sidebar.on('click', '.submenu-back', function (e) {
                 e.preventDefault();
                 closeSubmenus();
@@ -152,14 +159,6 @@
             $(document).on('keydown', function (e) {
                 if (e.key === 'Escape' && menuMobileAberto) {
                     setMobileOpen(false);
-                }
-            });
-
-            // Quando recolhido no desktop, hover na barra de ícones abre menu completo.
-            $iconbar.on('mouseenter', function () {
-                if (!desktopMedia.matches) return;
-                if (document.body.classList.contains('menu-desktop-collapsed')) {
-                    document.body.classList.add('menu-hover-open');
                 }
             });
 

--- a/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
+++ b/0 - Apresentacao/Sistema.MVC/wwwroot/js/site.js
@@ -56,6 +56,7 @@
             const alturaHeader = headerFixo ? Math.ceil($headerEl.outerHeight() || $headerEl[0]?.offsetHeight || 0) : 0;
 
             document.body.style.paddingTop = headerFixo && alturaHeader ? `${alturaHeader}px` : '';
+            root.style.setProperty('--layout-offset-top', headerFixo && alturaHeader ? `${alturaHeader}px` : '0px');
         };
 
         const atualizarEspacamentoFooter = () => {
@@ -65,6 +66,7 @@
             const alturaFooter = footerFixo ? Math.ceil($footerEl.outerHeight() || $footerEl[0]?.offsetHeight || 0) : 0;
 
             document.body.style.paddingBottom = footerFixo && alturaFooter ? `${alturaFooter}px` : '';
+            root.style.setProperty('--layout-offset-bottom', footerFixo && alturaFooter ? `${alturaFooter}px` : '0px');
         };
 
         const normalizarHex = (valor) => {
@@ -118,11 +120,8 @@
             }
 
             const $menu = $('#sidebarMenu');
-            const $iconbar = $('.app-iconbar');
             aplicarClasseTexto($menu, esquerdaClasse);
             aplicarClasseTexto($menu.find('.nav-link, .nav-header, .menu-brand-text *, .menu-user *'), esquerdaClasse);
-            aplicarClasseTexto($iconbar, esquerdaClasse);
-            aplicarClasseTexto($iconbar.find('.icon-link'), esquerdaClasse);
 
             const $temaPainel = $('#temaSidebar');
             aplicarClasseTexto($temaPainel, direitaClasse);
@@ -200,7 +199,6 @@
             ? window.initSistemaMenu({
                 sidebarSelector: '#sidebarMenu',
                 mobileToggleSelector: '.mobile-menu-toggle',
-                iconbarSelector: '.app-iconbar',
                 appShellSelector: '.app-shell',
                 expandedCheckboxSelector: '#MenuLateralExpandido',
                 onMobileStateChange: null

--- a/1 - Aplicacao/Sistema.APP/Services/LogAppService.cs
+++ b/1 - Aplicacao/Sistema.APP/Services/LogAppService.cs
@@ -132,6 +132,7 @@ public class LogAppService(IUnitOfWork uow, IHttpContextAccessor httpContextAcce
                 var item = JsonSerializer.Deserialize<Log>(linha);
                 if (item is not null)
                 {
+                    item.Id = 0;
                     if (item.DataOperacao == default)
                         item.DataOperacao = DateTime.UtcNow;
                     registrosValidos.Add(item);

--- a/artifacts/screenshots/capture-layout.mjs
+++ b/artifacts/screenshots/capture-layout.mjs
@@ -1,0 +1,169 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs/promises';
+
+const baseUrl = 'http://127.0.0.1:5080';
+const outDir = 'artifacts/screenshots';
+
+async function ensureNoLayoutBreak(page, name) {
+  const issues = await page.evaluate(() => {
+    const offenders = [];
+    const nodes = [document.documentElement, document.body, ...document.querySelectorAll('header, footer, nav, .app-shell, .content, .container, .container-fluid, .card')];
+    for (const el of nodes) {
+      if (!el) continue;
+      if (el.scrollWidth - el.clientWidth > 6) {
+        offenders.push({
+          tag: el.tagName,
+          className: el.className,
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth
+        });
+      }
+    }
+    return offenders;
+  });
+
+  if (issues.length) {
+    throw new Error(`Layout com overflow horizontal em ${name}: ${JSON.stringify(issues.slice(0, 5))}`);
+  }
+}
+
+async function screenshot(page, file) {
+  await page.screenshot({ path: `${outDir}/${file}`, fullPage: true });
+}
+
+async function openThemePanel(page) {
+  await page.click('#temaToggle');
+  await page.waitForSelector('#temaSidebar.show', { state: 'visible' });
+}
+
+async function closeThemePanel(page) {
+  if (await page.locator('#temaSidebar.show').count()) {
+    await page.click('#temaSidebarClose');
+    await page.waitForSelector('#temaSidebar.show', { state: 'hidden' });
+  }
+}
+
+async function setThemeToggle(page, id, checked) {
+  const locator = page.locator(id);
+  const isChecked = await locator.isChecked();
+  if (isChecked !== checked) {
+    await locator.click();
+  }
+  await page.waitForTimeout(250);
+}
+
+async function openSubmenu(page, title) {
+  const item = page.locator(`#sidebarMenu .nav-item:has(.nav-link[title="${title}"])`).first();
+  await item.locator('.nav-link').click();
+  await page.waitForTimeout(250);
+}
+
+async function clickSubitem(page, title, subTitle) {
+  await openSubmenu(page, title);
+  await page.evaluate(({ title, subTitle }) => {
+    const selector = `#sidebarMenu .nav-item .menu-subpanel a[title="${subTitle}"]`;
+    const candidates = Array.from(document.querySelectorAll(selector));
+    const target = candidates.find((el) => {
+      const parent = el.closest('.nav-item');
+      return parent?.querySelector(`.nav-link[title="${title}"]`);
+    });
+    if (!target) {
+      throw new Error(`Subitem não encontrado: ${title} > ${subTitle}`);
+    }
+
+    (target).click();
+  }, { title, subTitle });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(300);
+}
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await context.newPage();
+
+try {
+  await page.goto(`${baseUrl}/Account/Login`, { waitUntil: 'networkidle' });
+  await screenshot(page, '01-login.png');
+
+  await page.fill('input[name="Cpf"]', '00000000000');
+  await page.fill('input[name="Senha"]', 'admin123');
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/Home\/Index/);
+  await page.waitForLoadState('networkidle');
+
+  await ensureNoLayoutBreak(page, 'home-default');
+  await screenshot(page, '02-home-default.png');
+
+  await openThemePanel(page);
+  await setThemeToggle(page, '#HeaderFixo', true);
+  await closeThemePanel(page);
+  await ensureNoLayoutBreak(page, 'header-fixo-on');
+  await screenshot(page, '03-home-header-fixo-on.png');
+
+  await openThemePanel(page);
+  await setThemeToggle(page, '#HeaderFixo', false);
+  await closeThemePanel(page);
+  await ensureNoLayoutBreak(page, 'header-fixo-off');
+  await screenshot(page, '04-home-header-fixo-off.png');
+
+  await openThemePanel(page);
+  await setThemeToggle(page, '#FooterFixo', true);
+  await closeThemePanel(page);
+  await ensureNoLayoutBreak(page, 'footer-fixo-on');
+  await screenshot(page, '05-home-footer-fixo-on.png');
+
+  await openThemePanel(page);
+  await setThemeToggle(page, '#MenuLateralExpandido', false);
+  await closeThemePanel(page);
+  await ensureNoLayoutBreak(page, 'menu-colapsado');
+  await screenshot(page, '06-home-menu-colapsado.png');
+
+  await openThemePanel(page);
+  await setThemeToggle(page, '#MenuLateralExpandido', true);
+  await setThemeToggle(page, '#FooterFixo', false);
+  await closeThemePanel(page);
+  await ensureNoLayoutBreak(page, 'menu-expandido');
+  await screenshot(page, '07-home-menu-expandido.png');
+
+  const routes = [
+    ['Home', 'Privacidade', '08-privacy.png'],
+    ['Acesso', 'Segurança', '09-account-change-password.png'],
+    ['Comunicação', 'Feed', '10-mensagem-feed.png'],
+    ['Comunicação', 'Caixa de saída', '11-mensagem-caixa-saida.png'],
+    ['Comunicação', 'Nova publicação', '12-mensagem-nova.png'],
+    ['Administração', 'Configurações', '13-configuracao-index.png'],
+    ['Administração', 'Tema', '14-tema-edit.png'],
+    ['Documentação', 'Mensagens', '15-documentacao-mensagens.png'],
+    ['Documentação', 'Logs e auditoria', '16-documentacao-logs.png'],
+    ['Documentação', 'Scripts', '17-documentacao-scripts.png']
+  ];
+
+  for (const [title, subTitle, file] of routes) {
+    await clickSubitem(page, title, subTitle);
+    await ensureNoLayoutBreak(page, file);
+    await screenshot(page, file);
+  }
+
+  const mobile = await context.newPage();
+  await mobile.setViewportSize({ width: 390, height: 844 });
+  await mobile.goto(`${baseUrl}/Home/Index`, { waitUntil: 'networkidle' });
+  await mobile.click('.mobile-menu-toggle');
+  await mobile.waitForSelector('body.menu-mobile-open');
+  await ensureNoLayoutBreak(mobile, 'mobile-menu-open');
+  await screenshot(mobile, '18-mobile-menu-open.png');
+
+  await openThemePanel(mobile);
+  await setThemeToggle(mobile, '#HeaderFixo', true);
+  await setThemeToggle(mobile, '#FooterFixo', true);
+  await closeThemePanel(mobile);
+  await ensureNoLayoutBreak(mobile, 'mobile-theme-panel');
+  await screenshot(mobile, '19-mobile-theme-panel.png');
+
+  await mobile.close();
+
+  const files = (await fs.readdir(outDir)).filter(f => f.endsWith('.png')).sort();
+  console.log('Screenshots geradas:');
+  for (const f of files) console.log(` - ${outDir}/${f}`);
+} finally {
+  await browser.close();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "izimodal": "^1.6.0",
         "izitoast": "^1.4.0",
         "jquery": "^3.7.1",
+        "playwright": "^1.59.1",
         "sass": "^1.91.0",
         "vite": "^5.0.0"
       }
@@ -1310,6 +1311,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "izimodal": "^1.6.0",
     "izitoast": "^1.4.0",
     "jquery": "^3.7.1",
+    "playwright": "^1.59.1",
     "sass": "^1.91.0",
     "vite": "^5.0.0"
   }


### PR DESCRIPTION
### Motivation
- Improve the responsive layout and behavior of the application sidebar and content area to eliminate horizontal overflow and simplify the UI by removing the legacy icon bar.
- Add an automated layout check script to capture screenshots and detect horizontal overflow regressions.
- Ensure fallback log entries migrated from file to database do not carry conflicting identifiers.

### Description
- Converted the sidebar to a fixed panel and adjusted content spacing by introducing CSS variables `--layout-offset-top` and `--layout-offset-bottom`, updating `_menu.scss` and `site.css` to use `var(--mm-sidebar-panel-size)` for margin and to remove the old iconbar styles and layout hacks.
- Simplified `_Layout.cshtml` by removing the `.app-iconbar` markup, streamlining nav links to top-level module entries, and cleaning up unused user-initial code.
- Updated client scripts: `menu.js` no longer references the iconbar and now opens submenus when their parent `.nav-link` is clicked, and `site.js` sets the new layout offset CSS variables so content height/margins respond to fixed header/footer states.
- Added a Playwright-based layout test script `artifacts/screenshots/capture-layout.mjs` that logs in, navigates the app, asserts no horizontal overflow on major pages, and captures screenshots; added `playwright` to `package.json` and `package-lock.json`, and ignored generated screenshots in `.gitignore`.
- Fixed log migration in `LogAppService` by resetting `item.Id = 0` before bulk inserting migrated records to avoid primary key conflicts, and enabled in-memory DB for development by adding `UseInMemoryDatabase` in `appsettings.Development.json`.

### Testing
- No automated test suite was executed as part of this PR, but a Playwright script `artifacts/screenshots/capture-layout.mjs` was added to enable automated layout checks and screenshot generation when run locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a914fd4c832c8e11f2a4d79800b3)